### PR TITLE
Push Kit Fix

### DIFF
--- a/android-wrapper/app/src/main/AndroidManifest.xml
+++ b/android-wrapper/app/src/main/AndroidManifest.xml
@@ -4,12 +4,5 @@
 
     <application>
         <activity android:name=".activity.NativeBridgeActivity" />
-        <service
-            android:name=".push.HMSPushService"
-            android:exported="false">
-            <intent-filter>
-                <action android:name="com.huawei.push.action.MESSAGING_EVENT" />
-            </intent-filter>
-        </service>
     </application>
 </manifest>


### PR DESCRIPTION
Removed PushKitService from the manifest. This service gets included from Unity side.
The reason of removing is that this service gets included even though PushKit is not enabled.