### PR TITLE
Rewarded Ad Fix

### DIFF
--- a/hms-sdk-unity/HuaweiMobileServices/Ads/RewardAd.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Ads/RewardAd.cs
@@ -23,12 +23,12 @@
 
             public void OnRewardAdFailedToLoad(int errorCode)
             {
-                HMSDispatcher.InvokeAsync(() => { mOnError.Invoke(errorCode); });
+                mOnError.Invoke(errorCode);
             }
 
             public void OnRewardedLoaded()
             {
-                HMSDispatcher.InvokeAsync(() => { mOnSuccess.Invoke(); });
+                mOnSuccess.Invoke();
             }
         }
 
@@ -39,10 +39,15 @@
         public static RewardAd CreateRewardAdInstance() =>
             sJavaClass.CallStaticAsWrapper<RewardAd>("createRewardAdInstance", AndroidContext.ActivityContext);
 
-        
+
         public RewardAd(AndroidJavaObject javaObject) : base(javaObject) { }
 
-        public RewardAd(string paramString) : base("com.huawei.hms.ads.reward.RewardAd", AndroidContext.ActivityContext, paramString) { }
+        public RewardAd(string paramString) : base("com.huawei.hms.ads.reward.RewardAd", AndroidContext.ActivityContext, paramString)
+        {
+            AdId = paramString;
+        }
+
+        public string AdId { get; private set; }
 
         public virtual Reward Reward => CallAsWrapper<Reward>("getReward");
 
@@ -52,6 +57,11 @@
         {
             var listener = new LoadAdListener(onSuccess, onError);
             Call("loadAd", paramAdParam, new RewardAdLoadListener(listener));
+        }
+
+        public virtual void LoadAd(AdParam paramAdParam)
+        {
+            LoadAd(AdId, paramAdParam);
         }
 
         public virtual Task LoadAdAsync(AdParam paramAdParam)

--- a/hms-sdk-unity/HuaweiMobileServices/Ads/RewardAdListenerWrapper.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Ads/RewardAdListenerWrapper.cs
@@ -15,42 +15,42 @@
 
         public void onRewarded(AndroidJavaObject reward)
         {
-            this.CallOnMainThread(() => { mListener.OnRewarded(reward.AsWrapper<Reward>()); });
+            mListener.OnRewarded(reward.AsWrapper<Reward>());
         }
 
         public void onRewardAdClosed()
         {
-            this.CallOnMainThread(() => { mListener.OnRewardAdClosed(); });
+            mListener.OnRewardAdClosed();
         }
 
         public void onRewardAdFailedToLoad(int errorCode)
         {
-            this.CallOnMainThread(() => { mListener.OnRewardAdFailedToLoad(errorCode); });
+            mListener.OnRewardAdFailedToLoad(errorCode);
         }
 
         public void onRewardAdLeftApp()
         {
-            this.CallOnMainThread(() => { mListener.OnRewardAdLeftApp(); });
+            mListener.OnRewardAdLeftApp();
         }
 
         public void onRewardAdLoaded()
         {
-            this.CallOnMainThread(() => { mListener.OnRewardAdLoaded(); });
+            mListener.OnRewardAdLoaded();
         }
 
         public void onRewardAdOpened()
         {
-            this.CallOnMainThread(() => { mListener.OnRewardAdOpened(); });
+            mListener.OnRewardAdOpened();
         }
 
         public void onRewardAdCompleted()
         {
-            this.CallOnMainThread(() => { mListener.OnRewardAdCompleted(); });
+            mListener.OnRewardAdCompleted();
         }
 
         public void onRewardAdStarted()
         {
-            this.CallOnMainThread(() => { mListener.OnRewardAdStarted(); });
+            mListener.OnRewardAdStarted();
         }
     }
 }

--- a/hms-sdk-unity/HuaweiMobileServices/Ads/RewardAdLoadListener.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Ads/RewardAdLoadListener.cs
@@ -19,12 +19,12 @@
 
             public void onRewardedLoaded()
             {
-                this.CallOnMainThread(() => { mListener.OnRewardedLoaded(); });
+                mListener.OnRewardedLoaded();
             }
 
             public void onRewardAdFailedToLoad(int errorCode)
             {
-                this.CallOnMainThread(() => { mListener.OnRewardAdFailedToLoad(errorCode); });
+                mListener.OnRewardAdFailedToLoad(errorCode);
             }
         }
 

--- a/hms-sdk-unity/HuaweiMobileServices/Ads/RewardAdStatusListener.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Ads/RewardAdStatusListener.cs
@@ -7,7 +7,6 @@
     {
         private class RewardAdStatusListenerInterfaceWrapper : AndroidJavaProxy
         {
-
             private readonly IRewardAdStatusListener mListener;
 
             public RewardAdStatusListenerInterfaceWrapper(IRewardAdStatusListener listener) : base("org.m0skit0.android.hms.unity.ads.RewardAdStatusListener")
@@ -17,22 +16,22 @@
 
             public void onRewardAdClosed()
             {
-                this.CallOnMainThread(() => { mListener.OnRewardAdClosed(); });
+                mListener.OnRewardAdClosed();
             }
 
             public void onRewardAdFailedToShow(int errorCode)
             {
-                this.CallOnMainThread(() => { mListener.OnRewardAdFailedToShow(errorCode); });
+                mListener.OnRewardAdFailedToShow(errorCode);
             }
 
             public void onRewardAdOpened()
             {
-                this.CallOnMainThread(() => { mListener.OnRewardAdOpened(); });
+                mListener.OnRewardAdOpened();
             }
 
             public void onRewarded(AndroidJavaObject reward)
             {
-                this.CallOnMainThread(() => { mListener.OnRewarded(new Reward(reward)); });
+                mListener.OnRewarded(new Reward(reward));
             }
         }
 


### PR DESCRIPTION
Removed RewardAd callbacks that is called from Unity's main thread. They are getting called from Java's thread instead.