### PR TITLE
Upgrade Game Service to version 6.5.0.300 and encapsulate some functions

### DIFF
--- a/android-wrapper/app/build.gradle
+++ b/android-wrapper/app/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     compileOnly 'com.huawei.hms:nearby:5.2.0.301'
     compileOnly 'com.huawei.hms:iap:5.1.0.300'
     compileOnly 'com.huawei.hms:push:5.1.1.301'
-    compileOnly 'com.huawei.hms:game:5.0.4.302'
+    compileOnly 'com.huawei.hms:game:6.5.0.300'
     compileOnly 'com.huawei.hms:ads-lite:13.4.54.302'
     compileOnly 'com.huawei.hms:ads-installreferrer:3.4.39.302'
     compileOnly 'com.huawei.hms:scan:2.6.0.300'

--- a/android-wrapper/app/build.gradle
+++ b/android-wrapper/app/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     compileOnly 'com.huawei.hms:nearby:5.2.0.301'
     compileOnly 'com.huawei.hms:iap:5.1.0.300'
     compileOnly 'com.huawei.hms:push:5.1.1.301'
-    compileOnly 'com.huawei.hms:game:6.5.0.300'
+    compileOnly 'com.huawei.hms:game:6.8.0.300'
     compileOnly 'com.huawei.hms:ads-lite:13.4.54.302'
     compileOnly 'com.huawei.hms:ads-installreferrer:3.4.39.302'
     compileOnly 'com.huawei.hms:scan:2.6.0.300'

--- a/hms-sdk-unity/HuaweiMobileServices/Game/GamesClientWrapper.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Game/GamesClientWrapper.cs
@@ -7,8 +7,6 @@
 
     internal class GamesClientWrapper : JavaObjectWrapper, IGamesClient
     {
-
-        
         public GamesClientWrapper(AndroidJavaObject javaObject) : base(javaObject) { }
 
         public ITask<string> AppId => CallAsWrapper<TaskStringWrapper>("getAppId");

--- a/hms-sdk-unity/HuaweiMobileServices/Game/IPlayersClient.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Game/IPlayersClient.cs
@@ -13,6 +13,10 @@
 
         ITask<string> CachePlayerId { get; }
 
+        ITask<int> UserPlayState { get; }
+
+        ITask<bool> IsAllowContinuePlayGames { get; }
+
         ITask<Utils.Void> SavePlayerInfo(AppPlayerInfo paramAppPlayerInfo);
 
         ITask<Player> GetGamePlayer(bool isRequirePlayerId);

--- a/hms-sdk-unity/HuaweiMobileServices/Game/IPlayersClient.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Game/IPlayersClient.cs
@@ -1,7 +1,6 @@
 ﻿namespace HuaweiMobileServices.Game
 {
     using HuaweiMobileServices.Base;
-    using HuaweiMobileServices.Utils;
     using System;
 
     // Wrapper for com.huawei.hms.jos.games.PlayersClient

--- a/hms-sdk-unity/HuaweiMobileServices/Game/PlayersClientWrapper.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Game/PlayersClientWrapper.cs
@@ -6,8 +6,6 @@ namespace HuaweiMobileServices.Game
 
     internal class PlayersClientWrapper : JavaObjectWrapper, IPlayersClient
     {
-
-
         public PlayersClientWrapper(AndroidJavaObject javaObject) : base(javaObject) { }
 
         public ITask<Player> CurrentPlayer => CallAsWrapper<TaskJavaObjectWrapper<Player>>("getCurrentPlayer");

--- a/hms-sdk-unity/HuaweiMobileServices/Game/PlayersClientWrapper.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Game/PlayersClientWrapper.cs
@@ -18,6 +18,10 @@ namespace HuaweiMobileServices.Game
 
         public ITask<string> CachePlayerId => CallAsWrapper<TaskStringWrapper>("getCachePlayerId");
 
+        public ITask<int> UserPlayState => CallAsWrapper<TaskPrimitive<int>>("getUserPlayState");
+
+        public ITask<bool> IsAllowContinuePlayGames => CallAsWrapper<TaskPrimitive<bool>>("isAllowContinuePlayGames");
+
         public ITask<PlayerExtraInfo> GetPlayerExtraInfo(string transactionId) =>
              CallAsWrapper<TaskJavaObjectWrapper<PlayerExtraInfo>>("getPlayerExtraInfo", transactionId.AsJavaString());
 


### PR DESCRIPTION
This pull request upgrades the Game Service to version 6.5.0.300 and encapsulates two functions, namely UserPlayState and IsAllowContinuePlayGames. These functions should provide convenience for game developers who need to comply with China's age restriction policies for certain games. 

Related documents can be found at [https://developer.huawei.com/consumer/cn/doc/development/HMSCore-Guides/game-agequery-000000121767153](url) (only available in Chinese).


