### PR TITLE
Create Reconstruct, Meterial and Texture Sdk 3d modelling.

### DIFF
--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Abstract/Modeling3dTextureDownloadListener.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Abstract/Modeling3dTextureDownloadListener.cs
@@ -1,0 +1,49 @@
+using System;
+using HuaweiMobileServices.Utils;
+using UnityEngine;
+
+namespace HuaweiMobileServices.Modeling3D.MeterialGenerateSdk.Cloud
+{
+    
+    /// <summary>
+    /// Wrapper for com.huawei.hms.materialgeneratesdk.cloud.Modeling3dTextureDownloadListener.
+    /// <see cref="Modeling3dTextureDownloadListener" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dtexturedownloadlistener-0000001153213067"/>
+    /// </summary>
+    public class Modeling3dTextureDownloadListener : AndroidJavaProxy
+    {
+        private readonly IModeling3dTextureDownloadListener _IModeling3dTextureDownloadListener;
+
+        public Modeling3dTextureDownloadListener(IModeling3dTextureDownloadListener iModeling3dTextureDownloadListener) : base("com.huawei.hms.materialgeneratesdk.cloud.Modeling3dTextureDownloadListener")
+        {
+            _IModeling3dTextureDownloadListener = iModeling3dTextureDownloadListener;
+        }
+
+        public void onDownloadProgress(string taskId, double progress, AndroidJavaObject javaObject)
+        {
+            _IModeling3dTextureDownloadListener.onDownloadProgress(taskId.AsJavaString(), progress, javaObject);
+        }
+
+        public void onError(string taskId, int errorCode, string errorMsg)
+        {
+            _IModeling3dTextureDownloadListener.onError(taskId.AsJavaString(), errorCode, errorMsg.AsJavaString());
+        }
+
+        public void OnResult(string taskId, Modeling3dTextureDownloadResult result, AndroidJavaObject javaObject)
+        {
+            _IModeling3dTextureDownloadListener.OnResult(taskId.AsJavaString(), result, javaObject);
+        }
+
+        public interface IModeling3dTextureDownloadListener
+        {
+            //JavaObject maybe make problems be careful doing test.
+            void onDownloadProgress(AndroidJavaObject taskId, double progress, AndroidJavaObject javaObject);
+
+            void onError(AndroidJavaObject taskId, int errorCode, AndroidJavaObject errorMessage);
+
+            void OnResult(AndroidJavaObject taskId, Modeling3dTextureDownloadResult result, AndroidJavaObject javaObject);
+
+        }
+
+
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Abstract/Modeling3dTextureDownloadListener.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Abstract/Modeling3dTextureDownloadListener.cs
@@ -20,27 +20,27 @@ namespace HuaweiMobileServices.Modeling3D.MeterialGenerateSdk.Cloud
 
         public void onDownloadProgress(string taskId, double progress, AndroidJavaObject javaObject)
         {
-            _IModeling3dTextureDownloadListener.onDownloadProgress(taskId.AsJavaString(), progress, javaObject);
+            _IModeling3dTextureDownloadListener.onDownloadProgress(taskId, progress, javaObject);
         }
 
         public void onError(string taskId, int errorCode, string errorMsg)
         {
-            _IModeling3dTextureDownloadListener.onError(taskId.AsJavaString(), errorCode, errorMsg.AsJavaString());
+            _IModeling3dTextureDownloadListener.onError(taskId, errorCode, errorMsg);
         }
 
-        public void OnResult(string taskId, Modeling3dTextureDownloadResult result, AndroidJavaObject javaObject)
+        public void onResult(string taskId, Modeling3dTextureDownloadResult result, AndroidJavaObject javaObject)
         {
-            _IModeling3dTextureDownloadListener.OnResult(taskId.AsJavaString(), result, javaObject);
+            _IModeling3dTextureDownloadListener.onResult(taskId, result, javaObject);
         }
 
         public interface IModeling3dTextureDownloadListener
         {
-            //JavaObject maybe make problems be careful doing test.
-            void onDownloadProgress(AndroidJavaObject taskId, double progress, AndroidJavaObject javaObject);
+            //TODO: AndroidObject maybe make problems be careful doing test. AndroidObject = Android Object Class
+            void onDownloadProgress(string taskId, double progress, AndroidJavaObject javaObject);
 
-            void onError(AndroidJavaObject taskId, int errorCode, AndroidJavaObject errorMessage);
+            void onError(string taskId, int errorCode, string errorMessage);
 
-            void OnResult(AndroidJavaObject taskId, Modeling3dTextureDownloadResult result, AndroidJavaObject javaObject);
+            void onResult(string taskId, Modeling3dTextureDownloadResult result, AndroidJavaObject javaObject);
 
         }
 

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Abstract/Modeling3dTexturePreviewListener.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Abstract/Modeling3dTexturePreviewListener.cs
@@ -18,17 +18,17 @@ namespace HuaweiMobileServices.Modeling3D.MeterialGenerateSdk.Cloud
         }
         public void onError(string taskId, int errorCode, string errorMsg)
         {
-            _IModeling3dTexturePreviewListener.onError(taskId.AsJavaString(), errorCode, errorMsg.AsJavaString());
+            _IModeling3dTexturePreviewListener.onError(taskId, errorCode, errorMsg);
         }
-        public void OnResult(string taskId, AndroidJavaObject javaObject)
+        public void onResult(string taskId, AndroidJavaObject javaObject)
         {
-            _IModeling3dTexturePreviewListener.OnResult(taskId.AsJavaString(), javaObject);
+            _IModeling3dTexturePreviewListener.onResult(taskId, javaObject);
         }
 
         public interface IModeling3dTexturePreviewListener
         {
-            void onError(AndroidJavaObject taskId, int errorCode, AndroidJavaObject errorMessage);
-            void OnResult(AndroidJavaObject taskId,  AndroidJavaObject javaObject);
+            void onError(string taskId, int errorCode, string errorMessage);
+            void onResult(string taskId,  AndroidJavaObject javaObject);
 
         }
     }

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Abstract/Modeling3dTexturePreviewListener.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Abstract/Modeling3dTexturePreviewListener.cs
@@ -1,0 +1,35 @@
+using System;
+using HuaweiMobileServices.Utils;
+using UnityEngine;
+
+namespace HuaweiMobileServices.Modeling3D.MeterialGenerateSdk.Cloud
+{
+    
+    /// <summary>
+    /// Wrapper for com.huawei.hms.materialgeneratesdk.cloud.Modeling3dTexturePreviewListener.
+    /// <see cref="Modeling3dTexturePreviewListener" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dtexturepreviewlistener-0000001194914115"/>
+    /// </summary>
+    public class Modeling3dTexturePreviewListener : AndroidJavaProxy
+    {
+        private readonly IModeling3dTexturePreviewListener _IModeling3dTexturePreviewListener;
+        public Modeling3dTexturePreviewListener(IModeling3dTexturePreviewListener iModeling3dTexturePreviewListener) : base("com.huawei.hms.materialgeneratesdk.cloud.Modeling3dTexturePreviewListener")
+        {
+            _IModeling3dTexturePreviewListener = iModeling3dTexturePreviewListener;
+        }
+        public void onError(string taskId, int errorCode, string errorMsg)
+        {
+            _IModeling3dTexturePreviewListener.onError(taskId.AsJavaString(), errorCode, errorMsg.AsJavaString());
+        }
+        public void OnResult(string taskId, AndroidJavaObject javaObject)
+        {
+            _IModeling3dTexturePreviewListener.OnResult(taskId.AsJavaString(), javaObject);
+        }
+
+        public interface IModeling3dTexturePreviewListener
+        {
+            void onError(AndroidJavaObject taskId, int errorCode, AndroidJavaObject errorMessage);
+            void OnResult(AndroidJavaObject taskId,  AndroidJavaObject javaObject);
+
+        }
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Abstract/Modeling3dTextureUploadListener.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Abstract/Modeling3dTextureUploadListener.cs
@@ -1,10 +1,9 @@
-using System;
 using HuaweiMobileServices.Utils;
 using UnityEngine;
 
 namespace HuaweiMobileServices.Modeling3D.MeterialGenerateSdk.Cloud
 {
-    
+
     /// <summary>
     /// Wrapper for com.huawei.hms.materialgeneratesdk.cloud.Modeling3dTextureUploadListener.
     /// <see cref="Modeling3dTextureUploadListener" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dtextureuploadlistener-0000001153013001"/>
@@ -18,25 +17,25 @@ namespace HuaweiMobileServices.Modeling3D.MeterialGenerateSdk.Cloud
         }
         public void onUploadProgress(string taskId, double progress, AndroidJavaObject javaObject)
         {
-            _IModeling3dTextureUploadListener.onUploadProgress(taskId.AsJavaString(), progress, javaObject);
+            _IModeling3dTextureUploadListener.onUploadProgress(taskId, progress, javaObject);
         }
         public void onError(string taskId, int errorCode, string errorMsg)
         {
-            _IModeling3dTextureUploadListener.onError(taskId.AsJavaString(), errorCode, errorMsg.AsJavaString());
+            _IModeling3dTextureUploadListener.onError(taskId, errorCode, errorMsg);
         }
-        public void OnResult(string taskId, Modeling3dTextureUploadResult result, AndroidJavaObject javaObject)
+        public void onResult(string taskId, Modeling3dTextureUploadResult result, AndroidJavaObject javaObject)
         {
-            _IModeling3dTextureUploadListener.OnResult(taskId.AsJavaString(), result, javaObject);
+            _IModeling3dTextureUploadListener.onResult(taskId, result, javaObject);
         }
 
         public interface IModeling3dTextureUploadListener
         {
-            //JavaObject maybe make problems be careful doing test.
-            void onUploadProgress(AndroidJavaObject taskId, double progress, AndroidJavaObject javaObject);
+            //TODO: AndroidObject maybe make problems be careful doing test. AndroidObject = Android Object Class
+            void onUploadProgress(string taskId, double progress, AndroidJavaObject javaObject);
 
-            void onError(AndroidJavaObject taskId, int errorCode, AndroidJavaObject errorMessage);
+            void onError(string taskId, int errorCode, string errorMessage);
 
-            void OnResult(AndroidJavaObject taskId, Modeling3dTextureUploadResult result, AndroidJavaObject javaObject);
+            void onResult(string taskId, Modeling3dTextureUploadResult result, AndroidJavaObject javaObject);
 
         }
     }

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Abstract/Modeling3dTextureUploadListener.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Abstract/Modeling3dTextureUploadListener.cs
@@ -1,0 +1,43 @@
+using System;
+using HuaweiMobileServices.Utils;
+using UnityEngine;
+
+namespace HuaweiMobileServices.Modeling3D.MeterialGenerateSdk.Cloud
+{
+    
+    /// <summary>
+    /// Wrapper for com.huawei.hms.materialgeneratesdk.cloud.Modeling3dTextureUploadListener.
+    /// <see cref="Modeling3dTextureUploadListener" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dtextureuploadlistener-0000001153013001"/>
+    /// </summary>
+    public class Modeling3dTextureUploadListener : AndroidJavaProxy
+    {
+        private readonly IModeling3dTextureUploadListener _IModeling3dTextureUploadListener;
+        public Modeling3dTextureUploadListener(IModeling3dTextureUploadListener iModeling3dTextureUploadListener) : base("com.huawei.hms.materialgeneratesdk.cloud.Modeling3dTextureUploadListener")
+        {
+            _IModeling3dTextureUploadListener = iModeling3dTextureUploadListener;
+        }
+        public void onUploadProgress(string taskId, double progress, AndroidJavaObject javaObject)
+        {
+            _IModeling3dTextureUploadListener.onUploadProgress(taskId.AsJavaString(), progress, javaObject);
+        }
+        public void onError(string taskId, int errorCode, string errorMsg)
+        {
+            _IModeling3dTextureUploadListener.onError(taskId.AsJavaString(), errorCode, errorMsg.AsJavaString());
+        }
+        public void OnResult(string taskId, Modeling3dTextureUploadResult result, AndroidJavaObject javaObject)
+        {
+            _IModeling3dTextureUploadListener.OnResult(taskId.AsJavaString(), result, javaObject);
+        }
+
+        public interface IModeling3dTextureUploadListener
+        {
+            //JavaObject maybe make problems be careful doing test.
+            void onUploadProgress(AndroidJavaObject taskId, double progress, AndroidJavaObject javaObject);
+
+            void onError(AndroidJavaObject taskId, int errorCode, AndroidJavaObject errorMessage);
+
+            void OnResult(AndroidJavaObject taskId, Modeling3dTextureUploadResult result, AndroidJavaObject javaObject);
+
+        }
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureDownloadResult.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureDownloadResult.cs
@@ -1,0 +1,29 @@
+using HuaweiMobileServices.Utils;
+
+namespace  HuaweiMobileServices.Modeling3D.MeterialGenerateSdk.Cloud
+{
+        
+    /// <summary>
+    /// Wrapper for com.huawei.hms.materialgeneratesdk.cloud.Modeling3dTextureDownloadResult.
+    /// <see cref="Modeling3dTextureDownloadResult" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dtexturedownloadresult-0000001152893163"/>
+    /// </summary>
+    public class Modeling3dTextureDownloadResult : JavaObjectWrapper
+    {
+        public Modeling3dTextureDownloadResult(string taskId, bool isComplate) : base("com.huawei.hms.materialgeneratesdk.cloud.Modeling3dTextureDownloadResult", taskId.AsJavaString(), isComplate) { }
+
+        /// <summary>
+        /// Obtains the ID of a material generation task.
+        /// </summary>
+        /// <returns>ID of a material generation task. A unique task ID is generated each time the material generation API is called.</returns>
+        public string TaskId => CallAsString("getTaskId");
+
+        /// <summary>
+        /// Obtains the model download result.
+        /// </summary>
+        /// <returns>
+        /// Model download result. true: The model is downloaded successfully. false: The model fails to be downloaded.
+        /// </returns>
+        public bool IsComplate => Call<bool>("isComplate");
+
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureDownloadResult.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureDownloadResult.cs
@@ -23,7 +23,7 @@ namespace  HuaweiMobileServices.Modeling3D.MeterialGenerateSdk.Cloud
         /// <returns>
         /// Model download result. true: The model is downloaded successfully. false: The model fails to be downloaded.
         /// </returns>
-        public bool IsComplate => Call<bool>("isComplate");
+        public bool Complate => Call<bool>("isComplate");
 
     }
 }

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureEngine.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureEngine.cs
@@ -1,0 +1,99 @@
+using System.Threading.Tasks;
+using HuaweiMobileServices.Utils;
+using UnityEngine;
+
+namespace  HuaweiMobileServices.Modeling3D.MeterialGenerateSdk.Cloud
+{
+        
+    /// <summary>
+    /// Wrapper for com.huawei.hms.materialgeneratesdk.cloud.Modeling3dTextureEngine.
+    /// <see cref="Modeling3dTextureEngine" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dtextureengine-0000001106773052#section122241321310"/>
+    /// </summary>
+    public class Modeling3dTextureEngine : JavaObjectWrapper
+    {
+        public Modeling3dTextureEngine(AndroidJavaObject javaObject) : base(javaObject) { }
+        private static readonly AndroidJavaClass javaClass = new AndroidJavaClass("com.huawei.hms.materialgeneratesdk.cloud.Modeling3dTextureEngine");
+
+        /// <summary>
+        /// Obtains a Modeling3dTextureEngine instance.
+        /// <param name="context">Context</param>
+        /// </summary>
+        /// <returns>
+        /// Modeling3dTextureEngine instance
+        /// <see cref="Modeling3dTextureEngine:" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dtextureengine-0000001106773052"/>
+        /// </returns>
+        public Modeling3dTextureEngine GetInstance() => javaClass.CallStaticAsWrapper<Modeling3dTextureEngine>("getInstance",AndroidContext.ApplicationContext);
+        /// <summary>
+        /// Initializes the texture generation task.
+        /// <param name="taskId">Task ID.</param>
+        /// <param name="fileSavePath">Path to which the generated texture maps are to be saved.</param>
+        /// </summary>
+        public void AsyncDownloadTexture(string taskId, string fileSavePath) =>   javaClass.Call("asyncDownloadTexture", taskId.AsJavaString(), fileSavePath.AsJavaString());
+        /// <summary>
+        /// Uploads images and triggers a material generation task.
+        /// param name="taskId">Task ID.</param>
+        /// <param name="fileSavePath">Path from which images are to be uploaded.</param>
+        /// </summary>
+        public void AsyncUploadFile(string taskId, string filePath) => Call("asyncUploadFile", taskId.AsJavaString(), filePath.AsJavaString());
+        /// <summary>
+        /// Cancels texture map download.
+        /// <param name="taskId">Task ID.</param>
+        /// </summary>
+        /// <returns> 
+        /// Cancellation result. 0 indicates success, and other values indicate failure. 
+        /// <see cref="Other values" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/error-code-0000001153097761"/>
+        /// </returns>
+        public int CancelDownload(string taskId) => Call<int>("cancelDownload", taskId.AsJavaString());
+        /// <summary>
+        /// Cancels image upload.
+        /// <param name="taskId">Task ID.</param>
+        /// </summary>
+        /// <returns> 
+        /// Cancellation result. 0 indicates success, and other values indicate failure. 
+        /// <see cref="Other values" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/error-code-0000001153097761"/>
+        /// </returns>
+        public int CancelUpload(string taskId) => Call<int>("cancelUpload", taskId.AsJavaString());
+        /// <summary>
+        /// Disables the material generation engine.
+        /// </summary>
+        public void Close() => Call("close");
+        /// <summary>
+        /// Initializes a material generation task.
+        /// <param name="setting">Material generation task settings.</param>
+        /// </summary>
+        /// <returns> 
+        /// Initialization result.
+        /// <see cref="Modeling3dTextureInitResult " link="https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dtextureinitresult-0000001153093113"/>
+        /// </returns>
+        public Modeling3dTextureInitResult InitTask(Modeling3dTextureSetting setting) => CallAsWrapper<Modeling3dTextureInitResult>("initTask", setting);
+        /// <summary>
+        /// Previews the material.
+        /// <param name="taskId">ID of a material generation task.</param>
+        /// <param name="context">App context.</param>
+        /// <param name="previewListener">Listener for the preview.</param>
+        /// </summary>
+        public void PreviewTexture(string taskId, AndroidJavaObject context, Modeling3dTexturePreviewListener previewListener) => Call("previewTexture", taskId.AsJavaString(), context, previewListener);
+        /// <summary>
+        /// Sets the listener for texture map download.
+        /// <param name="listener">Instance of the texture map download listener.</param>
+        /// </summary>
+        public void SetTextureDownloadListener(Modeling3dTextureDownloadListener listener) => Call("setTextureDownloadListener", listener);
+        /// <summary>
+        /// Sets the listener for image upload.
+        /// <param name="listener">Instance of the image upload listener.</param>
+        /// </summary>
+        public void SetTextureUploadListener(Modeling3dTextureUploadListener listener) => Call("setTextureUploadListener", listener);
+        /// <summary>
+        /// Generates texture maps synchronously.
+        /// <param name="filePath">Path of images to be uploaded.</param>
+        /// <param name="fileSavePath">Path for storing the generated texture maps.</param>
+        /// <param name="setting">Material generation task settings.</param>
+        /// </summary>
+        /// <returns>
+        /// Texture map generation result. 0 indicates success, and other values indicate failure.
+        /// <see cref="Other values" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/error-code-0000001153097761"/>
+        /// </returns>    
+        public int SyncGenerateTexture(string filePath, string fileSavePath, Modeling3dTextureSetting setting) => Call<int>("syncGenerateTexture", filePath.AsJavaString(), fileSavePath.AsJavaString(), setting);
+
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureEngine.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureEngine.cs
@@ -72,7 +72,7 @@ namespace  HuaweiMobileServices.Modeling3D.MeterialGenerateSdk.Cloud
         /// <param name="context">App context.</param>
         /// <param name="previewListener">Listener for the preview.</param>
         /// </summary>
-        public void PreviewTexture(string taskId, AndroidJavaObject context, Modeling3dTexturePreviewListener previewListener) => Call("previewTexture", taskId.AsJavaString(), context, previewListener);
+        public void PreviewTexture(string taskId, Modeling3dTexturePreviewListener previewListener) => Call("previewTexture", taskId.AsJavaString(), AndroidContext.ApplicationContext, previewListener);
         /// <summary>
         /// Sets the listener for texture map download.
         /// <param name="listener">Instance of the texture map download listener.</param>

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureEngine.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureEngine.cs
@@ -22,7 +22,7 @@ namespace  HuaweiMobileServices.Modeling3D.MeterialGenerateSdk.Cloud
         /// Modeling3dTextureEngine instance
         /// <see cref="Modeling3dTextureEngine:" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dtextureengine-0000001106773052"/>
         /// </returns>
-        public Modeling3dTextureEngine GetInstance() => javaClass.CallStaticAsWrapper<Modeling3dTextureEngine>("getInstance",AndroidContext.ApplicationContext);
+        public static Modeling3dTextureEngine GetInstance() => javaClass.CallStaticAsWrapper<Modeling3dTextureEngine>("getInstance",AndroidContext.ApplicationContext);
         /// <summary>
         /// Initializes the texture generation task.
         /// <param name="taskId">Task ID.</param>

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureInitResult.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureInitResult.cs
@@ -1,0 +1,39 @@
+using HuaweiMobileServices.Utils;
+using UnityEngine;
+
+namespace  HuaweiMobileServices.Modeling3D.MeterialGenerateSdk.Cloud
+{
+        
+    /// <summary>
+    /// Wrapper for com.huawei.hms.materialgeneratesdk.cloud.Modeling3dTextureInitResult.
+    /// <see cref="Modeling3dTextureInitResult" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dtextureinitresult-0000001153093113"/>
+    /// </summary>
+    public class Modeling3dTextureInitResult : JavaObjectWrapper
+    {
+        public Modeling3dTextureInitResult(string taskId, int retCode, string retMsg) : base("com.huawei.hms.materialgeneratesdk.cloud.Modeling3dTextureInitResult", taskId.AsJavaString(), retCode, retMsg.AsJavaString()) { }
+
+        public Modeling3dTextureInitResult(AndroidJavaObject javaObject) : base(javaObject) { }
+
+        /// <summary>
+        /// Obtains the ID of a material generation task.
+        /// </summary>
+        /// <returns>ID of a material generation task. A unique task ID is generated each time the material generation API is called.</returns>
+        public string TaskId => CallAsString("getTaskId");
+
+        /// <summary>
+        /// Obtains the result code for material generation task initialization.
+        /// </summary>
+        /// <returns>
+        /// Result code. 0 indicates success, and other values indicate failure.
+        /// <see cref="other values" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/error-code-0000001153097761"/>
+        /// </returns>
+        public int RetCode => Call<int>("getRetCode");
+
+        /// <summary>
+        /// Obtains the description of the result code for material generation task initialization.
+        /// </summary>
+        /// <returns>Description of the result code.</returns>
+        public string RetMsg => CallAsString("getRetMsg");
+
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureQueryResult.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureQueryResult.cs
@@ -1,0 +1,46 @@
+using System;
+using HuaweiMobileServices.Utils;
+using UnityEngine;
+
+namespace  HuaweiMobileServices.Modeling3D.MeterialGenerateSdk.Cloud
+{
+        
+    /// <summary>
+    /// Wrapper for com.huawei.hms.materialgeneratesdk.cloud.Modeling3dTextureQueryResult.
+    /// <see cref="Modeling3dTextureQueryResult" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dtexturequeryresult-0000001106453242"/>
+    /// </summary>
+    public class Modeling3dTextureQueryResult : JavaObjectWrapper
+    {
+        public Modeling3dTextureQueryResult(string taskId, int retCode, string retMsg) : base("com.huawei.hms.materialgeneratesdk.cloud.Modeling3dTextureQueryResult", taskId.AsJavaString(), retCode, retMsg.AsJavaString()) { }
+
+        public Modeling3dTextureQueryResult(AndroidJavaObject javaObject) : base(javaObject) { }
+
+        /// <summary>
+        /// Obtains the ID of a material generation task.
+        /// </summary>
+        /// <returns>ID of a material generation task. A unique task ID is generated each time the material generation API is called.</returns>
+        public string TaskId => CallAsString("getTaskId");
+        /// <summary>
+        /// Obtains the result code for material generation task initialization.
+        /// </summary>
+        /// <returns>
+        /// Result code. 0 indicates success, and other values indicate failure.
+        /// <see cref="other values" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/error-code-0000001153097761"/>
+        /// </returns>
+        public int RetCode => Call<int>("getRetCode");
+        /// <summary>
+        /// Obtains the description of the result code for a material generation task.
+        /// </summary>
+        /// <returns>Description of the result code.</returns>
+        public string RetMsg => CallAsString("getRetMessage");
+        /// <summary>
+        /// Obtains the status of a material generation task.
+        /// </summary>
+        /// <returns>
+        /// Status of a material generation task.
+        /// <see cref="Status" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dtextureconstants-progressstatus-0000001106773050"/>
+        /// </returns>
+        public int Status => Call<int>("getStatus");
+
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureSetting.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureSetting.cs
@@ -24,7 +24,7 @@ namespace  HuaweiMobileServices.Modeling3D.MeterialGenerateSdk.Cloud
         public class Factory : JavaObjectWrapper
         {
             public Factory(AndroidJavaObject javaObject) : base(javaObject) { }
-            public Factory() : base("com.huawei.hms.materialgeneratesdk.cloud.materialgeneratesdk$Factory") { }
+            public Factory() : base("com.huawei.hms.materialgeneratesdk.cloud.Modeling3dTextureSetting$Factory") { }
 
             /// <summary>
             /// Creates a Modeling3dTextureSetting instance.

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureSetting.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureSetting.cs
@@ -1,0 +1,43 @@
+using System;
+using HuaweiMobileServices.Utils;
+using UnityEngine;
+
+namespace  HuaweiMobileServices.Modeling3D.MeterialGenerateSdk.Cloud
+{
+        
+    /// <summary>
+    /// Wrapper for com.huawei.hms.materialgeneratesdk.cloud.Modeling3dTextureSetting.
+    /// <see cref="Modeling3dTextureSetting" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dtexturesetting-0000001106773054"/>
+    /// </summary>
+    public class Modeling3dTextureSetting : JavaObjectWrapper
+    {
+        public Modeling3dTextureSetting(AndroidJavaObject javaObject) : base(javaObject) { }
+        public Modeling3dTextureSetting(int mode) : base("com.huawei.hms.materialgeneratesdk.cloud.Modeling3dTextureSetting", mode.AsJavaInteger()) { }
+        /// <summary>
+        /// Obtains the working mode for material generation.
+        /// </summary>
+        /// <returns>
+        /// <see cref="Working mode" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/algorithmmode-0000001117111976"/>
+        ///</returns>    
+        public int GetTextureMode() => CallAsInt("getTextureMode");
+    
+        public class Factory : JavaObjectWrapper
+        {
+            public Factory(AndroidJavaObject javaObject) : base(javaObject) { }
+            public Factory() : base("com.huawei.hms.materialgeneratesdk.cloud.materialgeneratesdk$Factory") { }
+
+            /// <summary>
+            /// Creates a Modeling3dTextureSetting instance.
+            /// </summary>
+            /// <returns> Modeling3dTextureSetting instance.</returns>
+            public Modeling3dTextureSetting Create() => CallAsWrapper<Modeling3dTextureSetting>("create");
+            /// <summary>
+            /// Creates a Modeling3dTextureSetting instance.
+            /// <param name="textureMode">/// Working mode for material generation. </param>
+            /// </summary>
+            /// <returns> Modeling3dTextureSetting.Factory instance.</returns>
+            public Factory SetTextureMode(int textureMode) => CallAsWrapper<Factory>("setTextureMode", textureMode.AsJavaInteger());
+
+        }
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureSetting.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureSetting.cs
@@ -12,14 +12,14 @@ namespace  HuaweiMobileServices.Modeling3D.MeterialGenerateSdk.Cloud
     public class Modeling3dTextureSetting : JavaObjectWrapper
     {
         public Modeling3dTextureSetting(AndroidJavaObject javaObject) : base(javaObject) { }
-        public Modeling3dTextureSetting(int mode) : base("com.huawei.hms.materialgeneratesdk.cloud.Modeling3dTextureSetting", mode.AsJavaInteger()) { }
+        public Modeling3dTextureSetting(int mode) : base("com.huawei.hms.materialgeneratesdk.cloud.Modeling3dTextureSetting", mode) { }
         /// <summary>
         /// Obtains the working mode for material generation.
         /// </summary>
         /// <returns>
         /// <see cref="Working mode" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/algorithmmode-0000001117111976"/>
         ///</returns>    
-        public int GetTextureMode() => CallAsInt("getTextureMode");
+        public int TextureMode => Call<int>("getTextureMode");
     
         public class Factory : JavaObjectWrapper
         {
@@ -36,7 +36,7 @@ namespace  HuaweiMobileServices.Modeling3D.MeterialGenerateSdk.Cloud
             /// <param name="textureMode">/// Working mode for material generation. </param>
             /// </summary>
             /// <returns> Modeling3dTextureSetting.Factory instance.</returns>
-            public Factory SetTextureMode(int textureMode) => CallAsWrapper<Factory>("setTextureMode", textureMode.AsJavaInteger());
+            public Factory SetTextureMode(int textureMode) => CallAsWrapper<Factory>("setTextureMode", textureMode);
 
         }
     }

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureTaskUtils.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureTaskUtils.cs
@@ -22,7 +22,7 @@ namespace  HuaweiMobileServices.Modeling3D.MeterialGenerateSdk.Cloud
         /// Modeling3dTextureTaskUtils instance
         /// <see cref="Modeling3dTextureTaskUtils:" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dtexturetaskutils-0000001106293436"/>
         /// </returns>
-        public Modeling3dTextureTaskUtils GetInstance() => javaClass.CallStaticAsWrapper<Modeling3dTextureTaskUtils>("getInstance",AndroidContext.ApplicationContext);
+        public static Modeling3dTextureTaskUtils GetInstance() => javaClass.CallStaticAsWrapper<Modeling3dTextureTaskUtils>("getInstance",AndroidContext.ApplicationContext);
         /// <summary>
         /// Deletes a material generation task using its ID.
         /// <param name="taskId">Task ID.</param>

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureTaskUtils.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureTaskUtils.cs
@@ -1,0 +1,60 @@
+using HuaweiMobileServices.Utils;
+using UnityEngine;
+
+namespace  HuaweiMobileServices.Modeling3D.MeterialGenerateSdk.Cloud
+{
+        
+    /// <summary>
+    /// Wrapper for com.huawei.hms.materialgeneratesdk.cloud.Modeling3dTextureTaskUtils.
+    /// <see cref="Modeling3dTextureTaskUtils" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dtexturetaskutils-0000001106293436"/>
+    /// </summary>
+    public class Modeling3dTextureTaskUtils : JavaObjectWrapper
+    {
+        public Modeling3dTextureTaskUtils(AndroidJavaObject javaObject) : base(javaObject) { }
+
+        private static readonly AndroidJavaClass javaClass = new AndroidJavaClass("com.huawei.hms.materialgeneratesdk.cloud.Modeling3dTextureTaskUtils");
+
+        /// <summary>
+        /// Obtains a Modeling3dTextureTaskUtils instance.
+        /// <param name="context">Context</param>
+        /// </summary>
+        /// <returns>
+        /// Modeling3dTextureTaskUtils instance
+        /// <see cref="Modeling3dTextureTaskUtils:" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dtexturetaskutils-0000001106293436"/>
+        /// </returns>
+        public Modeling3dTextureTaskUtils GetInstance() => javaClass.CallStaticAsWrapper<Modeling3dTextureTaskUtils>("getInstance",AndroidContext.ApplicationContext);
+        /// <summary>
+        /// Deletes a material generation task using its ID.
+        /// <param name="taskId">Task ID.</param>
+        /// </summary>
+        /// <returns>
+        /// Deletion result. 0 indicates success, and other values indicate failure.
+        /// <see cref="Other values:" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/error-code-0000001153097761"/>
+        /// </returns>
+        public int DeleteTask(string taskId) => Call<int>("deleteTask", taskId.AsJavaString());
+        /// <summary>
+        /// Queries the status of a material generation task.
+        /// </summary>
+        /// <param name="taskId">Task ID.</param>
+        /// <returns>Status of a material generation task.</returns>
+        public Modeling3dTextureQueryResult QueryTask(string taskId) => CallAsWrapper<Modeling3dTextureQueryResult>("queryTask", taskId.AsJavaString());
+        /// <summary>
+        /// Queries the restriction status of a material generation task using its ID.
+        /// </summary>
+        /// <param name="taskId">Task ID.</param>
+        /// <returns>
+        /// Restriction status. 0 indicates that the task is UNRESTRICT. 1 indicates that the task is RESTRICT. When the query fails, a result code is returned.
+        /// <see cref="Result Code:" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/error-code-0000001153097761"/>
+        /// </returns>
+        public int QueryTaskRestrictStatus(string taskId) => Call<int>("queryTaskRestrictStatus", taskId.AsJavaString());
+        /// <summary>
+        /// Sets the restriction status of a material generation task using its ID.
+        /// </summary>
+        /// <param name="taskId">Task ID.</param>
+        /// <param name="restrictStatus"Restriction status. (0 - UNRESTRICT, 1 - RESTRICT)</param>"
+        /// <see cref="Restriction status:" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dtextureconstantsrestrictstatus-0000001148991652"/>
+        /// <returns> Restriction status setting result. 0 indicates success, and other values indicate failure. </returns>
+        public int SetTaskRestrictStatus(string taskId, int restrictStatus) => Call<int>("setTaskRestrictStatus", taskId.AsJavaString(), restrictStatus);
+
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureUploadResult.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureUploadResult.cs
@@ -1,0 +1,40 @@
+using System;
+using HuaweiMobileServices.Utils;
+using UnityEngine;
+
+namespace  HuaweiMobileServices.Modeling3D.MeterialGenerateSdk.Cloud
+{
+        
+    /// <summary>
+    /// Wrapper for com.huawei.hms.materialgeneratesdk.cloud.Modeling3dTextureUploadResult.
+    /// <see cref="Modeling3dTextureUploadResult" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dtextureuploadresult-0000001106613204"/>
+    /// </summary>
+    public class Modeling3dTextureUploadResult : JavaObjectWrapper
+    {
+        public Modeling3dTextureUploadResult(AndroidJavaObject javaObject) : base(javaObject) { }
+
+        /// <summary>
+        /// Obtains the ID of a material generation task.
+        /// </summary>
+        /// <returns>ID of a material generation task. A unique task ID is generated each time the material generation API is called.</returns>
+        public string TaskId => CallAsString("getTaskId");
+        /// <summary>
+        /// Obtains the image upload result.
+        /// </summary>
+        /// <returns>
+        /// Model Upload  result. true: The model is uploaded successfully. false: The model fails to be uploaded.
+        /// </returns>
+        public bool IsComplate => Call<bool>("isComplate");
+        /// <summary>
+        /// Sets the ID of a material generation task.
+        /// <param name="taskId">Task ID.</param>
+        /// </summary>
+        public void SetTaskId(string taskId) => Call("setTaskId", taskId.AsJavaString());
+        /// <summary>
+        /// Obtains the ID of a material generation task.
+        /// <param name="isComplate">Whether the task is complete.</param>
+        /// </summary>
+        public void SetComplate(bool isComplate) => Call("setComplate", isComplate);
+
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureUploadResult.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Cloud/Modeling3dTextureUploadResult.cs
@@ -15,26 +15,26 @@ namespace  HuaweiMobileServices.Modeling3D.MeterialGenerateSdk.Cloud
 
         /// <summary>
         /// Obtains the ID of a material generation task.
+        /// <param name="taskId">Task ID.</param>
         /// </summary>
         /// <returns>ID of a material generation task. A unique task ID is generated each time the material generation API is called.</returns>
-        public string TaskId => CallAsString("getTaskId");
+        public string TaskId
+        {
+            get => CallAsString("getTaskId");
+            set => Call("setTaskId", value.AsJavaString());
+        }
         /// <summary>
         /// Obtains the image upload result.
+        /// <param name="isComplate">Whether the task is complete.</param>
         /// </summary>
         /// <returns>
         /// Model Upload  result. true: The model is uploaded successfully. false: The model fails to be uploaded.
         /// </returns>
-        public bool IsComplate => Call<bool>("isComplate");
-        /// <summary>
-        /// Sets the ID of a material generation task.
-        /// <param name="taskId">Task ID.</param>
-        /// </summary>
-        public void SetTaskId(string taskId) => Call("setTaskId", taskId.AsJavaString());
-        /// <summary>
-        /// Obtains the ID of a material generation task.
-        /// <param name="isComplate">Whether the task is complete.</param>
-        /// </summary>
-        public void SetComplate(bool isComplate) => Call("setComplate", isComplate);
-
+        public bool Complate
+        {
+            get => Call<bool>("isComplate");
+            set => Call("setComplate", value);
+        }
     }
+
 }

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/MeterialGenApplication.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/MeterialGenApplication.cs
@@ -20,7 +20,7 @@ namespace HuaweiMobileServices.Modeling3D.MeterialGenerateSdk
         /// Obtains the default app instance.
         /// </summary>
         /// <returns>Default app instance.</returns>
-        public static MeterialGenApplication GetInstance() => sJavaClass.GetStaticAsWrapper<MeterialGenApplication>("getInstance");
+        public static MeterialGenApplication GetInstance() => sJavaClass.CallStaticAsWrapper<MeterialGenApplication>("getInstance");
         /// <summary>
         /// Sets the access token for your app.
         /// </summary>

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/MeterialGenApplication.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/MeterialGenApplication.cs
@@ -1,0 +1,35 @@
+using HuaweiMobileServices.Utils;
+using UnityEngine;
+
+namespace HuaweiMobileServices.Modeling3D.MeterialGenerateSdk
+{
+    /// <summary>
+    /// App information. To use the on-cloud material generation service, set an access token or API key for your app.
+    /// Wrapper for com.huawei.hms.materialgeneratesdk.MaterialGenApplication.
+    /// <see cref=" MeterialGenApplication" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/materialgenapplication-0000001194908481"/>
+    /// </summary>
+    public class MeterialGenApplication : JavaObjectWrapper
+    {
+        public MeterialGenApplication(AndroidJavaObject javaObject) : base(javaObject)
+        {
+        }
+        private static AndroidJavaClass sJavaClass = new AndroidJavaClass("com.huawei.hms.meterialgeneratesdk.MeterialGenApplication");
+        public static explicit operator MeterialGenApplication(AndroidJavaObject javaObject) => javaObject == null ? null : new MeterialGenApplication(javaObject);
+
+        /// <summary>
+        /// Obtains the default app instance.
+        /// </summary>
+        /// <returns>Default app instance.</returns>
+        public MeterialGenApplication GetInstance() => sJavaClass.GetStaticAsWrapper<MeterialGenApplication>("getInstance");
+        /// <summary>
+        /// Sets the access token for your app.
+        /// </summary>
+        /// <param name="accessToken">Access token for your app.</param>
+        public void SetAccessToken (string accessToken) => Call("setAccessToken", accessToken.AsJavaString());
+        /// <summary>
+        /// Sets the API key for your app.
+        /// </summary>
+        /// <param name="apiKey">API key for your app.</param>
+        public void SetApiKey (string apiKey) => Call("setApiKey", apiKey.AsJavaString());
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/MeterialGenApplication.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/MeterialGenApplication.cs
@@ -20,7 +20,7 @@ namespace HuaweiMobileServices.Modeling3D.MeterialGenerateSdk
         /// Obtains the default app instance.
         /// </summary>
         /// <returns>Default app instance.</returns>
-        public MeterialGenApplication GetInstance() => sJavaClass.GetStaticAsWrapper<MeterialGenApplication>("getInstance");
+        public static MeterialGenApplication GetInstance() => sJavaClass.GetStaticAsWrapper<MeterialGenApplication>("getInstance");
         /// <summary>
         /// Sets the access token for your app.
         /// </summary>

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Modeling3dTextureConstants.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Modeling3dTextureConstants.cs
@@ -16,7 +16,7 @@ namespace HuaweiMobileServices.Modeling3D.MeterialGenerateSdk
         /// </summary>
         public class RestrictStatus : JavaObjectWrapper
         {
-            private const string CLASS_NAME = "com.huawei.hms.meterialgeneratesdk.Modeling3dTextureConstants$RestrictStatus";
+            private const string CLASS_NAME = "com.huawei.hms.materialgeneratesdk.Modeling3dTextureConstants$RestrictStatus";
             public RestrictStatus(AndroidJavaObject javaObject) : base(javaObject) { }
             public RestrictStatus() : base(CLASS_NAME) { }
             private static readonly AndroidJavaClass javaClass = new AndroidJavaClass(CLASS_NAME);
@@ -30,7 +30,7 @@ namespace HuaweiMobileServices.Modeling3D.MeterialGenerateSdk
         /// </summary>
         public class ProgressStatus : JavaObjectWrapper
         {
-            private const string CLASS_NAME = "com.huawei.hms.meterialgeneratesdk.Modeling3dTextureConstants$ProgressStatus";
+            private const string CLASS_NAME = "com.huawei.hms.materialgeneratesdk.Modeling3dTextureConstants$ProgressStatus";
             public ProgressStatus(AndroidJavaObject javaObject) : base(javaObject) { }
             public ProgressStatus() : base(CLASS_NAME) { }
 
@@ -68,7 +68,7 @@ namespace HuaweiMobileServices.Modeling3D.MeterialGenerateSdk
         /// </summary>
         public class AlgorithmMode : JavaObjectWrapper
         {
-            private const string CLASS_NAME = "com.huawei.hms.meterialgeneratesdk.Modeling3dTextureConstants$AlgorithmMode";
+            private const string CLASS_NAME = "com.huawei.hms.materialgeneratesdk.Modeling3dTextureConstants$AlgorithmMode";
             public AlgorithmMode(AndroidJavaObject javaObject) : base(javaObject) { }
             public AlgorithmMode() : base(CLASS_NAME) { }
             private static readonly AndroidJavaClass javaClass = new AndroidJavaClass(CLASS_NAME);

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Modeling3dTextureConstants.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Modeling3dTextureConstants.cs
@@ -1,0 +1,79 @@
+using HuaweiMobileServices.Utils;
+using UnityEngine;
+namespace HuaweiMobileServices.Modeling3D.MeterialGenerateSdk
+{
+    /// <summary>
+    /// Constants of material generation.
+    /// Wrapper for com.huawei.hms.materialgeneratesdk.Modeling3dTextureConstants.
+    /// <see cref="Modeling3dTextureConstants" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dtextureconstants-0000001152893159"/>
+    /// </summary>
+    public class Modeling3dTextureConstants : JavaObjectWrapper
+    {
+        public Modeling3dTextureConstants(AndroidJavaObject javaObject) : base(javaObject) { }
+        
+        //private static readonly AndroidJavaClass javaClass = new AndroidJavaClass("com.huawei.hms.meterialgeneratesdk.Modeling3dTextureConstants");
+
+        /// <summary>
+        /// Restriction status of a material generation task, which is specified in Modeling3dTextureConstants.
+        /// </summary>
+        public class RestrictStatus : JavaObjectWrapper
+        {
+            public RestrictStatus(AndroidJavaObject javaObject) : base(javaObject) { }
+
+            ///<returns>1</returns>
+            public int RESTRICT => CallStatic<int>("RESTRICT");
+            ///<returns>0</returns>
+            public int UNRESTRICT => CallStatic<int>("UNRESTRICT");
+
+        }
+
+        /// <summary>
+        /// Status of a material generation task, which is specified in Modeling3dTextureConstants.
+        /// </summary>
+        public class ProgressStatus : JavaObjectWrapper
+        {
+            public ProgressStatus(AndroidJavaObject javaObject) : base(javaObject) { }
+
+            ///<summary>
+            ///Task initialization is complete.
+            ///</summary>
+            ///<returns>0</returns>
+            public int INITED => CallStatic<int>("INITED");
+            ///<summary>
+            ///File upload is complete.
+            ///</summary>
+            ///<returns>1</returns>
+            public int UPLOAD_COMPLETED => CallStatic<int>("UPLOAD_COMPLETED");
+            ///<summary>
+            ///A material generation task starts.
+            ///</summary>
+            ///<returns>2</returns>
+            public int TEXTURE_START => CallStatic<int>("TEXTURE_START");
+            ///<summary>
+            ///A material generation task is complete.
+            ///</summary>
+            ///<returns>3</returns>
+            public int TEXTURE_COMPLETED => CallStatic<int>("TEXTURE_COMPLETED");
+            ///<summary>
+            ///A material generation task fails.
+            ///</summary>
+            ///<returns>4</returns>
+            public int TEXTURE_FAILED => CallStatic<int>("TEXTURE_FAILED");
+
+        }
+
+        /// <summary>
+        /// Working mode for material generation, which is specified in Modeling3dTextureConstants.
+        /// </summary>
+        public class AlgorithmMode : JavaObjectWrapper
+        {
+            public AlgorithmMode(AndroidJavaObject javaObject) : base(javaObject) { }
+
+            ///<summary>
+            ///AI mode.
+            ///</summary>
+            ///<returns>1</returns>
+            public int AI => CallStatic<int>("AI");
+        }
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Modeling3dTextureConstants.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Modeling3dTextureConstants.cs
@@ -11,75 +11,73 @@ namespace HuaweiMobileServices.Modeling3D.MeterialGenerateSdk
     {
         public Modeling3dTextureConstants(AndroidJavaObject javaObject) : base(javaObject) { }
         
-        //private static readonly AndroidJavaClass javaClass = new AndroidJavaClass("com.huawei.hms.meterialgeneratesdk.Modeling3dTextureConstants");
-
         /// <summary>
         /// Restriction status of a material generation task, which is specified in Modeling3dTextureConstants.
         /// </summary>
         public class RestrictStatus : JavaObjectWrapper
         {
+            private const string CLASS_NAME = "com.huawei.hms.meterialgeneratesdk.Modeling3dTextureConstants$RestrictStatus";
             public RestrictStatus(AndroidJavaObject javaObject) : base(javaObject) { }
-
-            public RestrictStatus() : base("com.huawei.hms.meterialgeneratesdk.Modeling3dTextureConstants$RestrictStatus") { }
-
+            public RestrictStatus() : base(CLASS_NAME) { }
+            private static readonly AndroidJavaClass javaClass = new AndroidJavaClass(CLASS_NAME);
             ///<returns>1</returns>
-            public int RESTRICT => CallStatic<int>("RESTRICT");
+            public static int RESTRICT => javaClass.GetStatic<int>("RESTRICT");
             ///<returns>0</returns>
-            public int UNRESTRICT => CallStatic<int>("UNRESTRICT");
-
+            public static int UNRESTRICT => javaClass.GetStatic<int>("UNRESTRICT");
         }
-
         /// <summary>
         /// Status of a material generation task, which is specified in Modeling3dTextureConstants.
         /// </summary>
         public class ProgressStatus : JavaObjectWrapper
         {
+            private const string CLASS_NAME = "com.huawei.hms.meterialgeneratesdk.Modeling3dTextureConstants$ProgressStatus";
             public ProgressStatus(AndroidJavaObject javaObject) : base(javaObject) { }
-            public ProgressStatus() : base("com.huawei.hms.meterialgeneratesdk.Modeling3dTextureConstants$ProgressStatus") { }
+            public ProgressStatus() : base(CLASS_NAME) { }
 
+            private static readonly AndroidJavaClass javaClass = new AndroidJavaClass(CLASS_NAME);
 
             ///<summary>
             ///Task initialization is complete.
             ///</summary>
             ///<returns>0</returns>
-            public int INITED => CallStatic<int>("INITED");
+            public static int INITED => javaClass.GetStatic<int>("INITED");
             ///<summary>
             ///File upload is complete.
             ///</summary>
             ///<returns>1</returns>
-            public int UPLOAD_COMPLETED => CallStatic<int>("UPLOAD_COMPLETED");
+            public static int UPLOAD_COMPLETED => javaClass.GetStatic<int>("UPLOAD_COMPLETED");
             ///<summary>
             ///A material generation task starts.
             ///</summary>
             ///<returns>2</returns>
-            public int TEXTURE_START => CallStatic<int>("TEXTURE_START");
+            public static int TEXTURE_START => javaClass.GetStatic<int>("TEXTURE_START");
             ///<summary>
             ///A material generation task is complete.
             ///</summary>
             ///<returns>3</returns>
-            public int TEXTURE_COMPLETED => CallStatic<int>("TEXTURE_COMPLETED");
+            public static int TEXTURE_COMPLETED => javaClass.GetStatic<int>("TEXTURE_COMPLETED");
             ///<summary>
             ///A material generation task fails.
             ///</summary>
             ///<returns>4</returns>
-            public int TEXTURE_FAILED => CallStatic<int>("TEXTURE_FAILED");
+            public static int TEXTURE_FAILED => javaClass.GetStatic<int>("TEXTURE_FAILED");
 
         }
-
         /// <summary>
         /// Working mode for material generation, which is specified in Modeling3dTextureConstants.
         /// </summary>
         public class AlgorithmMode : JavaObjectWrapper
         {
+            private const string CLASS_NAME = "com.huawei.hms.meterialgeneratesdk.Modeling3dTextureConstants$AlgorithmMode";
             public AlgorithmMode(AndroidJavaObject javaObject) : base(javaObject) { }
-            public AlgorithmMode() : base("com.huawei.hms.meterialgeneratesdk.Modeling3dTextureConstants$AlgorithmMode") { }
-
+            public AlgorithmMode() : base(CLASS_NAME) { }
+            private static readonly AndroidJavaClass javaClass = new AndroidJavaClass(CLASS_NAME);
 
             ///<summary>
             ///AI mode.
             ///</summary>
             ///<returns>1</returns>
-            public int AI => CallStatic<int>("AI");
+            public static int AI => javaClass.GetStatic<int>("AI");
         }
     }
 }

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Modeling3dTextureConstants.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Modeling3dTextureConstants.cs
@@ -20,6 +20,8 @@ namespace HuaweiMobileServices.Modeling3D.MeterialGenerateSdk
         {
             public RestrictStatus(AndroidJavaObject javaObject) : base(javaObject) { }
 
+            public RestrictStatus() : base("com.huawei.hms.meterialgeneratesdk.Modeling3dTextureConstants$RestrictStatus") { }
+
             ///<returns>1</returns>
             public int RESTRICT => CallStatic<int>("RESTRICT");
             ///<returns>0</returns>
@@ -33,6 +35,8 @@ namespace HuaweiMobileServices.Modeling3D.MeterialGenerateSdk
         public class ProgressStatus : JavaObjectWrapper
         {
             public ProgressStatus(AndroidJavaObject javaObject) : base(javaObject) { }
+            public ProgressStatus() : base("com.huawei.hms.meterialgeneratesdk.Modeling3dTextureConstants$ProgressStatus") { }
+
 
             ///<summary>
             ///Task initialization is complete.
@@ -68,6 +72,8 @@ namespace HuaweiMobileServices.Modeling3D.MeterialGenerateSdk
         public class AlgorithmMode : JavaObjectWrapper
         {
             public AlgorithmMode(AndroidJavaObject javaObject) : base(javaObject) { }
+            public AlgorithmMode() : base("com.huawei.hms.meterialgeneratesdk.Modeling3dTextureConstants$AlgorithmMode") { }
+
 
             ///<summary>
             ///AI mode.

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Modeling3dTextureErrors.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Modeling3dTextureErrors.cs
@@ -12,153 +12,153 @@ namespace HuaweiMobileServices.Modeling3D.MeterialGenerateSdk
         {
         }
         //Not necessary to implement this because class name is the same as the java class name
-        //private static AndroidJavaClass sJavaClass = new AndroidJavaClass("com.huawei.hms.materialgeneratesdk.Modeling3dTextureErrors");
+        private static AndroidJavaClass sJavaClass = new AndroidJavaClass("com.huawei.hms.materialgeneratesdk.Modeling3dTextureErrors");
 
         /// <summary>
         /// Authentication failed.
         /// </summary>
         /// <returns>1201</returns>
-        public int ERR_AUTHORIZE_FAILED => CallStatic<int>("ERR_AUTHORIZE_FAILED");
+        public static int ERR_AUTHORIZE_FAILED => sJavaClass.GetStatic<int>("ERR_AUTHORIZE_FAILED");
         /// <summary>
         /// The data processing location is not set.
         /// </summary>
         /// <return>1203</return>
-        public int ERR_DATA_PROCESSING_LOCATION_NOT_SET => CallStatic<int>("ERR_DATA_PROCESSING_LOCATION_NOT_SET");
+        public static int ERR_DATA_PROCESSING_LOCATION_NOT_SET => sJavaClass.GetStatic<int>("ERR_DATA_PROCESSING_LOCATION_NOT_SET");
         /// <summary>
         /// Failed to delete the uploaded files from the cloud.
         /// </summary>
         /// <returns>1231</returns>
-        public int ERR_DELETE_REMOTE_TASK_FAILED => CallStatic<int>("ERR_DELETE_REMOTE_TASK_FAILED");
+        public static int ERR_DELETE_REMOTE_TASK_FAILED => sJavaClass.GetStatic<int>("ERR_DELETE_REMOTE_TASK_FAILED");
         /// <summary>
         /// Failed to cancel the download.
         /// </summary>
         /// <returns>1229</returns>
-        public int ERR_DOWNLOAD_CANCEL_FAILED => CallStatic<int>("ERR_DOWNLOAD_CANCEL_FAILED");
+        public static int ERR_DOWNLOAD_CANCEL_FAILED => sJavaClass.GetStatic<int>("ERR_DOWNLOAD_CANCEL_FAILED");
         /// <summary>
         /// Download failed.
         /// </summary>
         /// <returns>1227</returns>
-        public int ERR_DOWNLOAD_FAILED => CallStatic<int>("ERR_DOWNLOAD_FAILED");
+        public static int ERR_DOWNLOAD_FAILED => sJavaClass.GetStatic<int>("ERR_DOWNLOAD_FAILED");
         /// <summary>
         /// The material generation engine is busy.
         /// </summary>
         /// <returns>1220</returns>
-        public int ERR_ENGINE_BUSY => CallStatic<int>("ERR_ENGINE_BUSY");
+        public static int ERR_ENGINE_BUSY => sJavaClass.GetStatic<int>("ERR_ENGINE_BUSY");
         /// <summary>
         /// The image file does not exist.
         /// </summary>
         /// <returns>1213</returns>
-        public int ERR_FILE_NOT_FOUND => CallStatic<int>("ERR_FILE_NOT_FOUND");
+        public static int ERR_FILE_NOT_FOUND => sJavaClass.GetStatic<int>("ERR_FILE_NOT_FOUND");
         /// <summary>
         /// The number of images exceeds the maximum.
         /// </summary>
         /// <returns>1211</returns>
-        public int ERR_FILE_NUM_OVERFLOW => CallStatic<int>("ERR_FILE_NUM_OVERFLOW");
+        public static int ERR_FILE_NUM_OVERFLOW => sJavaClass.GetStatic<int>("ERR_FILE_NUM_OVERFLOW");
         /// <summary>
         /// The image file size is too large.
         /// </summary>
         /// <returns>1212</returns>
-        public int ERR_FILE_SIZE_OVERFLOW => CallStatic<int>("ERR_FILE_SIZE_OVERFLOW");
+        public static int ERR_FILE_SIZE_OVERFLOW => sJavaClass.GetStatic<int>("ERR_FILE_SIZE_OVERFLOW");
         /// <summary>
         /// Invalid parameter.
         /// </summary>
         /// <returns>1200</returns>
-        public int ERR_ILLEGAL_PARAMETER => CallStatic<int>("ERR_ILLEGAL_PARAMETER");
+        public static int ERR_ILLEGAL_PARAMETER => sJavaClass.GetStatic<int>("ERR_ILLEGAL_PARAMETER");
         /// <summary>
         /// Invalid task status.
         /// </summary>
         /// <returns>1205</returns>
-        public int ERR_ILLEGAL_TASK_STATUS => CallStatic<int>("ERR_ILLEGAL_TASK_STATUS");
+        public static int ERR_ILLEGAL_TASK_STATUS => sJavaClass.GetStatic<int>("ERR_ILLEGAL_TASK_STATUS");
         /// <summary>
         /// The access token is invalid or has expired.
         /// </summary>
         /// <returns>1202</returns>
-        public int ERR_ILLEGAL_TOKEN => CallStatic<int>("ERR_ILLEGAL_TOKEN");
+        public static int ERR_ILLEGAL_TOKEN => sJavaClass.GetStatic<int>("ERR_ILLEGAL_TOKEN");
         /// <summary>
         /// Unsupported image format.
         /// </summary>
         /// <returns>1210</returns>
-        public int ERR_IMAGE_FILE_NOTSUPPORTED => CallStatic<int>("ERR_IMAGE_FILE_NOTSUPPORTED");
+        public static int ERR_IMAGE_FILE_NOTSUPPORTED => sJavaClass.GetStatic<int>("ERR_IMAGE_FILE_NOTSUPPORTED");
         /// <summary>
         /// Unsupported input image resolution.
         /// </summary>
         /// <returns>1214</returns>
-        public int ERR_IMAGE_RESOLUTION_NOTSUPPORTED => CallStatic<int>("ERR_IMAGE_RESOLUTION_NOTSUPPORTED");
+        public static int ERR_IMAGE_RESOLUTION_NOTSUPPORTED => sJavaClass.GetStatic<int>("ERR_IMAGE_RESOLUTION_NOTSUPPORTED");
         /// <summary>
         /// Insufficient device storage space.
         /// </summary>
         /// <returns>1226</returns>
-        public int ERR_INSUFFICIENT_SPACE => CallStatic<int>("ERR_INSUFFICIENT_SPACE");
+        public static int ERR_INSUFFICIENT_SPACE => sJavaClass.GetStatic<int>("ERR_INSUFFICIENT_SPACE");
         /// <summary>
         /// Internal error.
         /// </summary>
         /// <returns>1298</returns>
-        public int ERR_INTERNAL => CallStatic<int>("ERR_INTERNAL");
+        public static int ERR_INTERNAL => sJavaClass.GetStatic<int>("ERR_INTERNAL");
         /// <summary>
         /// Failed to preview the generated material.
         /// </summary>
         /// <returns>1230</returns>
-        public int ERR_MODEL_PREVIEW_FAILED => CallStatic<int>("ERR_MODEL_PREVIEW_FAILED");
+        public static int ERR_MODEL_PREVIEW_FAILED => sJavaClass.GetStatic<int>("ERR_MODEL_PREVIEW_FAILED");
         /// <summary>
         /// Network connection error.
         /// </summary>
         /// <returns>1221</returns>
-        public int ERR_NETCONNECT_FAILED => CallStatic<int>("ERR_NETCONNECT_FAILED");
+        public static int ERR_NETCONNECT_FAILED => sJavaClass.GetStatic<int>("ERR_NETCONNECT_FAILED");
         /// <summary>
         /// Query failed.
         /// </summary>
         /// <returns>1225</returns>
-        public int ERR_QUERY_FAILED => CallStatic<int>("ERR_QUERY_FAILED");
+        public static int ERR_QUERY_FAILED => sJavaClass.GetStatic<int>("ERR_QUERY_FAILED");
         /// <summary>
         /// The number of API calls exceeds the maximum.
         /// </summary>
         /// <returns>1208</returns>
-        public int ERR_RET_OVER_MAX_LIMIT => CallStatic<int>("ERR_RET_OVER_MAX_LIMIT");
+        public static int ERR_RET_OVER_MAX_LIMIT => sJavaClass.GetStatic<int>("ERR_RET_OVER_MAX_LIMIT");
         /// <summary>
         /// Server error.
         /// </summary>
         /// <returns>1206</returns>
-        public int ERR_SERVICE_EXCEPTION => CallStatic<int>("ERR_SERVICE_EXCEPTION");
+        public static int ERR_SERVICE_EXCEPTION => sJavaClass.GetStatic<int>("ERR_SERVICE_EXCEPTION");
         /// <summary>
         /// The task result has expired.
         /// </summary>
         /// <returns>1207</returns>
-        public int ERR_TASK_EXPIRED => CallStatic<int>("ERR_TASK_EXPIRED");
+        public static int ERR_TASK_EXPIRED => sJavaClass.GetStatic<int>("ERR_TASK_EXPIRED");
         /// <summary>
         /// Task initialization failed.
         /// </summary>
         /// <returns>1222</returns>
-        public int ERR_TASK_INIT_FAILED => CallStatic<int>("ERR_TASK_INIT_FAILED");
+        public static int ERR_TASK_INIT_FAILED => sJavaClass.GetStatic<int>("ERR_TASK_INIT_FAILED");
         /// <summary>
         /// The task is restricted.
         /// </summary>
         /// <returns>1209</returns>
-        public int ERR_TASK_RESTRICTED => CallStatic<int>("ERR_TASK_RESTRICTED");
+        public static int ERR_TASK_RESTRICTED => sJavaClass.GetStatic<int>("ERR_TASK_RESTRICTED");
         /// <summary>
         /// The task is being executed and cannot be submitted again.
         /// </summary>
         /// <returns>1223</returns>
-        public int ERR_TASKID_ALREADY_INPROGRESS => CallStatic<int>("ERR_TASKID_ALREADY_INPROGRESS");
+        public static int ERR_TASKID_ALREADY_INPROGRESS => sJavaClass.GetStatic<int>("ERR_TASKID_ALREADY_INPROGRESS");
         /// <summary>
         /// The task does not exist.
         /// </summary>
         /// <returns>1204</returns>
-        public int ERR_TASKID_NOT_EXISTED => CallStatic<int>("ERR_TASKID_NOT_EXISTED");
+        public static int ERR_TASKID_NOT_EXISTED => sJavaClass.GetStatic<int>("ERR_TASKID_NOT_EXISTED");
         /// <summary>
         /// Failed to cancel the upload.
         /// </summary>
         /// <returns>1228</returns>
-        public int ERR_UPLOAD_CANCEL_FAILED => CallStatic<int>("ERR_UPLOAD_CANCEL_FAILED");
+        public static int ERR_UPLOAD_CANCEL_FAILED => sJavaClass.GetStatic<int>("ERR_UPLOAD_CANCEL_FAILED");
         /// <summary>
         /// File upload failed.
         /// </summary>
         /// <returns>1224</returns>
-        public int ERR_UPLOAD_FILE_FAILED => CallStatic<int>("ERR_UPLOAD_FILE_FAILED");
+        public static int ERR_UPLOAD_FILE_FAILED => sJavaClass.GetStatic<int>("ERR_UPLOAD_FILE_FAILED");
         /// <summary>
         /// Unknown error.
         /// </summary>
         /// <returns>1299</returns>
-        public int ERR_UNKNOWN => CallStatic<int>("ERR_UNKNOWN");
+        public static int ERR_UNKNOWN => sJavaClass.GetStatic<int>("ERR_UNKNOWN");
 
 
     }

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Modeling3dTextureErrors.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Modeling3dTextureErrors.cs
@@ -20,6 +20,9 @@ namespace HuaweiMobileServices.Modeling3D.MeterialGenerateSdk
         /// <returns>1201</returns>
         public int ERR_AUTHORIZE_FAILED => CallStatic<int>("ERR_AUTHORIZE_FAILED");
         /// <summary>
+        /// The data processing location is not set.
+        /// </summary>
+        /// <return>1203</return>
         public int ERR_DATA_PROCESSING_LOCATION_NOT_SET => CallStatic<int>("ERR_DATA_PROCESSING_LOCATION_NOT_SET");
         /// <summary>
         /// Failed to delete the uploaded files from the cloud.

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Modeling3dTextureErrors.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/MeterialGenerateSdk/Modeling3dTextureErrors.cs
@@ -1,0 +1,162 @@
+using HuaweiMobileServices.Utils;
+using UnityEngine;
+namespace HuaweiMobileServices.Modeling3D.MeterialGenerateSdk
+{
+    /// <summary>
+    /// Wrapper for com.huawei.hms.materialgeneratesdk.Modeling3dTextureErrors.
+    /// <see cref="Modeling3dTextureErrors" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dtextureerrors-0000001106293434"/>
+    /// </summary>
+    public class Modeling3dTextureErrors : JavaObjectWrapper
+    {
+        public Modeling3dTextureErrors(AndroidJavaObject javaObject) : base(javaObject)
+        {
+        }
+        //Not necessary to implement this because class name is the same as the java class name
+        //private static AndroidJavaClass sJavaClass = new AndroidJavaClass("com.huawei.hms.materialgeneratesdk.Modeling3dTextureErrors");
+
+        /// <summary>
+        /// Authentication failed.
+        /// </summary>
+        /// <returns>1201</returns>
+        public int ERR_AUTHORIZE_FAILED => CallStatic<int>("ERR_AUTHORIZE_FAILED");
+        /// <summary>
+        public int ERR_DATA_PROCESSING_LOCATION_NOT_SET => CallStatic<int>("ERR_DATA_PROCESSING_LOCATION_NOT_SET");
+        /// <summary>
+        /// Failed to delete the uploaded files from the cloud.
+        /// </summary>
+        /// <returns>1231</returns>
+        public int ERR_DELETE_REMOTE_TASK_FAILED => CallStatic<int>("ERR_DELETE_REMOTE_TASK_FAILED");
+        /// <summary>
+        /// Failed to cancel the download.
+        /// </summary>
+        /// <returns>1229</returns>
+        public int ERR_DOWNLOAD_CANCEL_FAILED => CallStatic<int>("ERR_DOWNLOAD_CANCEL_FAILED");
+        /// <summary>
+        /// Download failed.
+        /// </summary>
+        /// <returns>1227</returns>
+        public int ERR_DOWNLOAD_FAILED => CallStatic<int>("ERR_DOWNLOAD_FAILED");
+        /// <summary>
+        /// The material generation engine is busy.
+        /// </summary>
+        /// <returns>1220</returns>
+        public int ERR_ENGINE_BUSY => CallStatic<int>("ERR_ENGINE_BUSY");
+        /// <summary>
+        /// The image file does not exist.
+        /// </summary>
+        /// <returns>1213</returns>
+        public int ERR_FILE_NOT_FOUND => CallStatic<int>("ERR_FILE_NOT_FOUND");
+        /// <summary>
+        /// The number of images exceeds the maximum.
+        /// </summary>
+        /// <returns>1211</returns>
+        public int ERR_FILE_NUM_OVERFLOW => CallStatic<int>("ERR_FILE_NUM_OVERFLOW");
+        /// <summary>
+        /// The image file size is too large.
+        /// </summary>
+        /// <returns>1212</returns>
+        public int ERR_FILE_SIZE_OVERFLOW => CallStatic<int>("ERR_FILE_SIZE_OVERFLOW");
+        /// <summary>
+        /// Invalid parameter.
+        /// </summary>
+        /// <returns>1200</returns>
+        public int ERR_ILLEGAL_PARAMETER => CallStatic<int>("ERR_ILLEGAL_PARAMETER");
+        /// <summary>
+        /// Invalid task status.
+        /// </summary>
+        /// <returns>1205</returns>
+        public int ERR_ILLEGAL_TASK_STATUS => CallStatic<int>("ERR_ILLEGAL_TASK_STATUS");
+        /// <summary>
+        /// The access token is invalid or has expired.
+        /// </summary>
+        /// <returns>1202</returns>
+        public int ERR_ILLEGAL_TOKEN => CallStatic<int>("ERR_ILLEGAL_TOKEN");
+        /// <summary>
+        /// Unsupported image format.
+        /// </summary>
+        /// <returns>1210</returns>
+        public int ERR_IMAGE_FILE_NOTSUPPORTED => CallStatic<int>("ERR_IMAGE_FILE_NOTSUPPORTED");
+        /// <summary>
+        /// Unsupported input image resolution.
+        /// </summary>
+        /// <returns>1214</returns>
+        public int ERR_IMAGE_RESOLUTION_NOTSUPPORTED => CallStatic<int>("ERR_IMAGE_RESOLUTION_NOTSUPPORTED");
+        /// <summary>
+        /// Insufficient device storage space.
+        /// </summary>
+        /// <returns>1226</returns>
+        public int ERR_INSUFFICIENT_SPACE => CallStatic<int>("ERR_INSUFFICIENT_SPACE");
+        /// <summary>
+        /// Internal error.
+        /// </summary>
+        /// <returns>1298</returns>
+        public int ERR_INTERNAL => CallStatic<int>("ERR_INTERNAL");
+        /// <summary>
+        /// Failed to preview the generated material.
+        /// </summary>
+        /// <returns>1230</returns>
+        public int ERR_MODEL_PREVIEW_FAILED => CallStatic<int>("ERR_MODEL_PREVIEW_FAILED");
+        /// <summary>
+        /// Network connection error.
+        /// </summary>
+        /// <returns>1221</returns>
+        public int ERR_NETCONNECT_FAILED => CallStatic<int>("ERR_NETCONNECT_FAILED");
+        /// <summary>
+        /// Query failed.
+        /// </summary>
+        /// <returns>1225</returns>
+        public int ERR_QUERY_FAILED => CallStatic<int>("ERR_QUERY_FAILED");
+        /// <summary>
+        /// The number of API calls exceeds the maximum.
+        /// </summary>
+        /// <returns>1208</returns>
+        public int ERR_RET_OVER_MAX_LIMIT => CallStatic<int>("ERR_RET_OVER_MAX_LIMIT");
+        /// <summary>
+        /// Server error.
+        /// </summary>
+        /// <returns>1206</returns>
+        public int ERR_SERVICE_EXCEPTION => CallStatic<int>("ERR_SERVICE_EXCEPTION");
+        /// <summary>
+        /// The task result has expired.
+        /// </summary>
+        /// <returns>1207</returns>
+        public int ERR_TASK_EXPIRED => CallStatic<int>("ERR_TASK_EXPIRED");
+        /// <summary>
+        /// Task initialization failed.
+        /// </summary>
+        /// <returns>1222</returns>
+        public int ERR_TASK_INIT_FAILED => CallStatic<int>("ERR_TASK_INIT_FAILED");
+        /// <summary>
+        /// The task is restricted.
+        /// </summary>
+        /// <returns>1209</returns>
+        public int ERR_TASK_RESTRICTED => CallStatic<int>("ERR_TASK_RESTRICTED");
+        /// <summary>
+        /// The task is being executed and cannot be submitted again.
+        /// </summary>
+        /// <returns>1223</returns>
+        public int ERR_TASKID_ALREADY_INPROGRESS => CallStatic<int>("ERR_TASKID_ALREADY_INPROGRESS");
+        /// <summary>
+        /// The task does not exist.
+        /// </summary>
+        /// <returns>1204</returns>
+        public int ERR_TASKID_NOT_EXISTED => CallStatic<int>("ERR_TASKID_NOT_EXISTED");
+        /// <summary>
+        /// Failed to cancel the upload.
+        /// </summary>
+        /// <returns>1228</returns>
+        public int ERR_UPLOAD_CANCEL_FAILED => CallStatic<int>("ERR_UPLOAD_CANCEL_FAILED");
+        /// <summary>
+        /// File upload failed.
+        /// </summary>
+        /// <returns>1224</returns>
+        public int ERR_UPLOAD_FILE_FAILED => CallStatic<int>("ERR_UPLOAD_FILE_FAILED");
+        /// <summary>
+        /// Unknown error.
+        /// </summary>
+        /// <returns>1299</returns>
+        public int ERR_UNKNOWN => CallStatic<int>("ERR_UNKNOWN");
+
+
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ModelingCaptureSdk/Abstract/Modeling3dCaptureImageListener.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ModelingCaptureSdk/Abstract/Modeling3dCaptureImageListener.cs
@@ -1,0 +1,54 @@
+﻿using UnityEngine;
+
+namespace HuaweiMobileServices.Modeling3D.ModelingCaptureSdk
+{
+    /// <summary>
+    /// Wrapper for com.huawei.hms.modeling3dcapturesdk.cloud.Modeling3dCaptureImageListener.
+    /// <see cref="Modeling3dCaptureImageListener" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/captureimagelistener-0000001271452336"/>
+    /// </summary>
+    public class Modeling3dCaptureImageListener : AndroidJavaProxy
+    {
+        private readonly IModeling3dCaptureImageListener _IModeling3dCaptureImageListener;
+
+        public Modeling3dCaptureImageListener(IModeling3dCaptureImageListener iModeling3dCaptureImageListener) : base("com.huawei.hms.modeling3dcapturesdk.Modeling3dCaptureImageListener")
+        {
+            _IModeling3dCaptureImageListener = iModeling3dCaptureImageListener;
+        }
+
+        public void onProgress(int progress)
+        {
+            _IModeling3dCaptureImageListener.onProgress(progress);
+        }
+
+        public void onError(int errorCode, string errorMsg)
+        {
+            _IModeling3dCaptureImageListener.onError(errorCode, errorMsg);
+        }
+
+        public void onResult()
+        {
+            _IModeling3dCaptureImageListener.onResult();
+        }
+
+        public interface IModeling3dCaptureImageListener
+        {
+            /// <summary>
+            /// Callback when image collection is complete.
+            /// </summary>
+            void onResult();
+            /// <summary>
+            /// Callback when an error occurs during image collection.
+            /// </summary>
+            /// <param name="progress">Collection progress.</param>
+            void onProgress(int progress);
+            /// <summary>
+            /// Callback when an error occurs during image collection. You can process the error according to the returned result code.
+            /// </summary>
+            /// <param name="errorCode">Result code.</param>
+            /// <param name="message">Result description.</param>
+            void onError(int errorCode, string message);
+
+        }
+    }
+}
+

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ModelingCaptureSdk/Modeling3dCaptureErrors.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ModelingCaptureSdk/Modeling3dCaptureErrors.cs
@@ -1,0 +1,42 @@
+﻿using HuaweiMobileServices.Utils;
+using UnityEngine;
+
+namespace HuaweiMobileServices.Modeling3D.ModelingCaptureSdk
+{
+    /// <summary>
+    /// Wrapper for com.huawei.hms.modeling3dcapturesdk.Modeling3dCaptureErrors.
+    /// <see cref="Modeling3dCaptureErrors" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3derrors-0000001322601245"/>
+    /// </summary>
+    public class Modeling3dCaptureErrors : JavaObjectWrapper
+    {
+        public Modeling3dCaptureErrors(AndroidJavaObject androidJavaObject) : base(androidJavaObject) { }
+        private static readonly AndroidJavaClass sJavaClass = new AndroidJavaClass("com.huawei.hms.modeling3dcapturesdk.Modeling3dCaptureErrors");
+
+        /// <summary>
+        /// The device does not support the real-time guide mode.
+        /// </summary>
+        /// <return>1300</return>
+        public static int ERR_DEVICE_NOT_SUPPORTED => sJavaClass.GetStatic<int>("ERR_DEVICE_NOT_SUPPORTED");
+        /// <summary>
+        /// Image path verification failed.
+        /// </summary>
+        /// <return>1301</return>
+        public static int ERR_FILE_PATH_VERIFIED_FAILED => sJavaClass.GetStatic<int>("ERR_FILE_PATH_VERIFIED_FAILED");
+        /// <summary>
+        /// The parameter of the bounding hemisphere is invalid.
+        /// </summary>
+        /// <return>1302</return>
+        public static int ERR_ILLEGAL_BOX_PARAMETER => sJavaClass.GetStatic<int>("ERR_ILLEGAL_BOX_PARAMETER");
+        /// <summary>
+        /// Internal processing error.
+        /// </summary>
+        /// <return>1303</return>
+        public static int ERR_INTERNAL_PROCESS => sJavaClass.GetStatic<int>("ERR_INTERNAL_PROCESS");
+        /// <summary>
+        /// The required dependency is not integrated.
+        /// </summary>
+        /// <return>1304</return>
+        public static int ERR_DEPENDENCY_NOT_INTEGRATED => sJavaClass.GetStatic<int>("ERR_DEPENDENCY_NOT_INTEGRATED");
+    }
+
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ModelingCaptureSdk/Modeling3dCaptureImageEngine.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ModelingCaptureSdk/Modeling3dCaptureImageEngine.cs
@@ -1,0 +1,33 @@
+﻿
+using HuaweiMobileServices.Utils;
+using UnityEngine;
+
+namespace HuaweiMobileServices.Modeling3D.ModelingCaptureSdk
+{
+    /// <summary>
+    /// Wrapper for com.huawei.hms.modeling3dcapturesdk.Modeling3dCaptureImageEngine
+    /// <see cref="Modeling3dCaptureImageEngine" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/captureimageengine-0000001322733925"/>
+    /// </summary>
+    public class Modeling3dCaptureImageEngine: JavaObjectWrapper
+    {
+        public Modeling3dCaptureImageEngine(AndroidJavaObject javaObject) : base(javaObject) { }
+        private static readonly AndroidJavaClass javaClass = new AndroidJavaClass("com.huawei.hms.modeling3dcapturesdk.Modeling3dCaptureImageEngine");
+
+        /// <summary>
+        /// Obtains an instance of Modeling3dCaptureImageEngine.
+        /// </summary>
+        /// <returns>Instance of Modeling3dCaptureImageEngine.</returns>
+        public static Modeling3dCaptureImageEngine GetInstance() => javaClass.CallStaticAsWrapper<Modeling3dCaptureImageEngine>("getInstance");
+        /// <summary>
+        /// Starts image collection.
+        /// </summary>
+        /// <param name="fileSavePath">Path for storing the collected image.</param>
+        /// <param name="listener">Image collection listener.</param>
+        public void CaptureImage(string fileSavePath, Modeling3dCaptureImageListener listener) => Call("captureImage", fileSavePath, AndroidContext.ApplicationContext, listener);
+        /// <summary>
+        /// Configures the real-time guide engine.
+        /// </summary>
+        /// <param name="setting">Configuration of the real-time guide engine.</param>
+        public void SetCaptureConfig(Modeling3dCaptureSetting setting) => Call("setCaptureConfig", setting);
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ModelingCaptureSdk/Modeling3dCaptureImageEngine.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ModelingCaptureSdk/Modeling3dCaptureImageEngine.cs
@@ -23,7 +23,7 @@ namespace HuaweiMobileServices.Modeling3D.ModelingCaptureSdk
         /// </summary>
         /// <param name="fileSavePath">Path for storing the collected image.</param>
         /// <param name="listener">Image collection listener.</param>
-        public void CaptureImage(string fileSavePath, Modeling3dCaptureImageListener listener) => Call("captureImage", fileSavePath, AndroidContext.ApplicationContext, listener);
+        public void CaptureImage(string fileSavePath, AndroidJavaObject context, Modeling3dCaptureImageListener listener) => Call("captureImage", fileSavePath, context, listener);
         /// <summary>
         /// Configures the real-time guide engine.
         /// </summary>

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ModelingCaptureSdk/Modeling3dCaptureSetting.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ModelingCaptureSdk/Modeling3dCaptureSetting.cs
@@ -1,0 +1,66 @@
+﻿
+using HuaweiMobileServices.Modeling3D.MeterialGenerateSdk.Cloud;
+using HuaweiMobileServices.Utils;
+using UnityEngine;
+
+namespace HuaweiMobileServices.Modeling3D.ModelingCaptureSdk
+{
+    /// <summary>
+    /// Wrapper for com.huawei.hms.modeling3dcapturesdk.Modeling3dCaptureSetting.
+    /// <see cref="Modeling3dCaptureSetting" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructcapturesetting-0000001322414221"/>
+    /// </summary>
+    public class Modeling3dCaptureSetting : JavaObjectWrapper
+    {
+        public Modeling3dCaptureSetting(AndroidJavaObject javaObject) : base(javaObject) { }
+        public Modeling3dCaptureSetting(int azimuthNum, int latitudeNum, double radius) : base("com.huawei.hms.modeling3dcapturesdk.Modeling3dCaptureSetting", azimuthNum,latitudeNum,radius) { }
+
+        /// <summary>
+        /// Obtains the number of boxes at each layer of the bounding hemisphere.
+        /// </summary>
+        /// <return>Number of boxes at each layer of the bounding hemisphere.</return>
+        public int AzimuthNum => Call<int>("getAzimuthNum");
+        /// <summary>
+        /// Obtains the number of layers of the bounding hemisphere.
+        /// </summary>
+        /// <return>Number of layers of the bounding hemisphere.</return>
+        public int LatitudeNum => Call<int>("getLatitudeNum");
+        /// <summary>
+        /// Obtains the radius of the bounding hemisphere.
+        /// </summary>
+        /// <return>Radius of the bounding hemisphere.</return>
+        public double Radius => Call<double>("getRadius");
+
+
+        public class Factory: JavaObjectWrapper
+        {
+            public Factory(AndroidJavaObject javaObject) : base(javaObject) { }
+            public Factory() : base("com.huawei.hms.modeling3dcapturesdk.Modeling3dCaptureSetting$Factory") { }
+
+            /// <summary>
+            /// Sets the number of boxes at each layer of the bounding hemisphere.
+            /// </summary>
+            /// <param name="azimuthNum">Number of boxes at each layer of the bounding hemisphere. The value range is [20,50].</param>
+            /// <returns>Instance of Modeling3dCaptureSetting.Factory.</returns>
+            public Factory SetAzimuthNum(int azimuthNum) => CallAsWrapper<Factory>("setAzimuthNum", azimuthNum);
+            /// <summary>
+            /// Sets the number of layers of the bounding hemisphere.
+            /// </summary>
+            /// <param name="latitudeNum">Number of layers of the bounding hemisphere. The value range is [1,6].</param>
+            /// <returns>Instance of Modeling3dCaptureSetting.Factory.</returns>
+            public Factory SetLatitudeNum(int latitudeNum) => CallAsWrapper<Factory>("setLatitudeNum", latitudeNum);
+            /// <summary>
+            /// Sets the radius of the bounding hemisphere.
+            /// </summary>
+            /// <param name="radius">Sets the radius of the bounding hemisphere.</param>
+            /// <returns>	Instance of Modeling3dCaptureSetting.Factory.</returns>
+            public Factory SetRadius(double radius) => CallAsWrapper<Factory>("setRadius", radius);
+            /// <summary>
+            /// Creates an instance of Modeling3dCaptureSetting.
+            /// </summary>
+            /// <returns>Instance of Modeling3dCaptureSetting.</returns>
+            public Modeling3dCaptureSetting Create() => CallAsWrapper<Modeling3dCaptureSetting>("create");
+
+        }
+
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Abstract/IModeling3dReconstructDownloadListener.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Abstract/IModeling3dReconstructDownloadListener.cs
@@ -1,0 +1,45 @@
+using System;
+using UnityEngine;
+
+namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
+{
+    public class Modeling3dReconstructDownloadListener : AndroidJavaProxy
+    {
+        //wrapper for com.huawei.hms.objreconstructsdk.cloud.IModeling3dReconstructDownloadListener
+        //https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructdownloadlistener-0000001106613206
+
+        private readonly IModeling3dReconstructDownloadListener _IModeling3dReconstructDownloadListener;
+
+        public Modeling3dReconstructDownloadListener(IModeling3dReconstructDownloadListener iModeling3dReconstructDownloadListener) : base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructDownloadListener")
+        {
+            _IModeling3dReconstructDownloadListener = iModeling3dReconstructDownloadListener;
+        }
+
+        public void onDownloadProgress(String taskId, double progress, AndroidJavaObject javaObject)
+        {
+            _IModeling3dReconstructDownloadListener.onDownloadProgress(taskId, progress, javaObject);
+        }
+
+        public void onError(String taskId, int errorCode, String errorMsg)
+        {
+            _IModeling3dReconstructDownloadListener.onError(taskId, errorCode, errorMsg);
+        }
+
+        public void OnResult(String taskId, Modeling3dReconstructDownloadResult result, AndroidJavaObject javaObject)
+        {
+            _IModeling3dReconstructDownloadListener.OnResult(taskId, result, javaObject);
+        }
+
+    }
+
+    public interface IModeling3dReconstructDownloadListener
+    {
+        //JavaObject maybe make problems be careful doing test.
+        void onDownloadProgress(String taskId, double progress, AndroidJavaObject javaObject);
+
+        void onError(String taskId, int errorCode, String errorMessage);
+
+        void OnResult(String taskId, Modeling3dReconstructDownloadResult result, AndroidJavaObject javaObject);
+
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Abstract/IModeling3dReconstructPreviewListener.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Abstract/IModeling3dReconstructPreviewListener.cs
@@ -1,0 +1,37 @@
+using System;
+using UnityEngine;
+
+namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
+{
+    public class Modeling3dReconstructPreviewListener : AndroidJavaProxy
+    {
+        //wrapper for com.huawei.hms.objreconstructsdk.cloud.IModeling3dReconstructPreviewListener
+        //https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructdownloadlistener-0000001106613206
+
+        private readonly IModeling3dReconstructPreviewListener _IModeling3dReconstructPreviewListener;
+
+        public Modeling3dReconstructPreviewListener(IModeling3dReconstructPreviewListener IModeling3dReconstructPreviewListener) : base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructPreviewListener")
+        {
+            _IModeling3dReconstructPreviewListener = IModeling3dReconstructPreviewListener;
+        }
+
+        public void onError(String taskId, int errorCode, String errorMsg)
+        {
+            _IModeling3dReconstructPreviewListener.onError(taskId, errorCode, errorMsg);
+        }
+
+        public void OnResult(String taskId, AndroidJavaObject javaObject)
+        {
+            _IModeling3dReconstructPreviewListener.OnResult(taskId, javaObject);
+        }
+
+    }
+
+    public interface IModeling3dReconstructPreviewListener
+    {
+        void onError(String taskId, int errorCode, String message);
+
+        void OnResult(String taskId, AndroidJavaObject javaObject);
+
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Abstract/IModeling3dReconstructUploadListener.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Abstract/IModeling3dReconstructUploadListener.cs
@@ -1,0 +1,45 @@
+using System;
+using UnityEngine;
+
+namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
+{
+    public class Modeling3dReconstructUploadListener : AndroidJavaProxy
+    {
+        //wrapper for com.huawei.hms.objreconstructsdk.cloud.IModeling3dReconstructUploadListener
+        //https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructuploadlistener-0000001153093115
+
+        private readonly IModeling3dReconstructUploadListener _IModeling3dReconstructUploadListener;
+
+        public Modeling3dReconstructUploadListener(IModeling3dReconstructUploadListener IModeling3dReconstructUploadListener) : base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructDownloadListener")
+        {
+            _IModeling3dReconstructUploadListener = IModeling3dReconstructUploadListener;
+        }
+
+        public void onUploadProgress(String taskId, double progress, AndroidJavaObject javaObject)
+        {
+            _IModeling3dReconstructUploadListener.onDownloadProgress(taskId, progress, javaObject);
+        }
+
+        public void onError(String taskId, int errorCode, String errorMsg)
+        {
+            _IModeling3dReconstructUploadListener.onError(taskId, errorCode, errorMsg);
+        }
+
+        public void OnResult(String taskId, Modeling3dReconstructUploadResult result, AndroidJavaObject javaObject)
+        {
+            _IModeling3dReconstructUploadListener.OnResult(taskId, result, javaObject);
+        }
+
+    }
+
+    public interface IModeling3dReconstructUploadListener
+    {
+        //JavaObject maybe make problems be careful doing test.
+        void onDownloadProgress(String taskId, double progress, AndroidJavaObject javaObject);
+
+        void onError(String taskId, int errorCode, String errorMessage);
+
+        void OnResult(String taskId, Modeling3dReconstructUploadResult result, AndroidJavaObject javaObject);
+
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Abstract/Modeling3dReconstructDownloadListener.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Abstract/Modeling3dReconstructDownloadListener.cs
@@ -5,7 +5,7 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
 {
     public class Modeling3dReconstructDownloadListener : AndroidJavaProxy
     {
-        //wrapper for com.huawei.hms.objreconstructsdk.cloud.IModeling3dReconstructDownloadListener
+        //wrapper for com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructDownloadListener
         //https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructdownloadlistener-0000001106613206
 
         private readonly IModeling3dReconstructDownloadListener _IModeling3dReconstructDownloadListener;
@@ -15,19 +15,19 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
             _IModeling3dReconstructDownloadListener = iModeling3dReconstructDownloadListener;
         }
 
-        public void onDownloadProgress(String taskId, double progress, AndroidJavaObject javaObject)
+        public void onDownloadProgress(string taskId, double progress, AndroidJavaObject javaObject)
         {
             _IModeling3dReconstructDownloadListener.onDownloadProgress(taskId, progress, javaObject);
         }
 
-        public void onError(String taskId, int errorCode, String errorMsg)
+        public void onError(string taskId, int errorCode, string errorMsg)
         {
             _IModeling3dReconstructDownloadListener.onError(taskId, errorCode, errorMsg);
         }
 
-        public void OnResult(String taskId, Modeling3dReconstructDownloadResult result, AndroidJavaObject javaObject)
+        public void onResult(string taskId, Modeling3dReconstructDownloadResult result, AndroidJavaObject javaObject)
         {
-            _IModeling3dReconstructDownloadListener.OnResult(taskId, result, javaObject);
+            _IModeling3dReconstructDownloadListener.onResult(taskId, result, javaObject);
         }
 
     }
@@ -35,11 +35,11 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
     public interface IModeling3dReconstructDownloadListener
     {
         //JavaObject maybe make problems be careful doing test.
-        void onDownloadProgress(String taskId, double progress, AndroidJavaObject javaObject);
+        void onDownloadProgress(string taskId, double progress, AndroidJavaObject javaObject);
 
-        void onError(String taskId, int errorCode, String errorMessage);
+        void onError(string taskId, int errorCode, string errorMessage);
 
-        void OnResult(String taskId, Modeling3dReconstructDownloadResult result, AndroidJavaObject javaObject);
+        void onResult(string taskId, Modeling3dReconstructDownloadResult result, AndroidJavaObject javaObject);
 
     }
 }

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Abstract/Modeling3dReconstructDownloadListener.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Abstract/Modeling3dReconstructDownloadListener.cs
@@ -25,9 +25,9 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
             _IModeling3dReconstructDownloadListener.onError(taskId, errorCode, errorMsg);
         }
 
-        public void onResult(string taskId, Modeling3dReconstructDownloadResult result, AndroidJavaObject javaObject)
+        public void onResult(string taskId, AndroidJavaObject result, AndroidJavaObject javaObject)
         {
-            _IModeling3dReconstructDownloadListener.onResult(taskId, result, javaObject);
+            _IModeling3dReconstructDownloadListener.onResult(taskId, (Modeling3dReconstructDownloadResult)result, javaObject);
         }
 
     }

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Abstract/Modeling3dReconstructPreviewListener.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Abstract/Modeling3dReconstructPreviewListener.cs
@@ -20,9 +20,9 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
             _IModeling3dReconstructPreviewListener.onError(taskId, errorCode, errorMsg);
         }
 
-        public void OnResult(string taskId, AndroidJavaObject javaObject)
+        public void onResult(string taskId, AndroidJavaObject javaObject)
         {
-            _IModeling3dReconstructPreviewListener.OnResult(taskId, javaObject);
+            _IModeling3dReconstructPreviewListener.onResult(taskId, javaObject);
         }
 
     }
@@ -31,7 +31,7 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
     {
         void onError(string taskId, int errorCode, string message);
 
-        void OnResult(string taskId, AndroidJavaObject javaObject);
+        void onResult(string taskId, AndroidJavaObject javaObject);
 
     }
 }

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Abstract/Modeling3dReconstructPreviewListener.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Abstract/Modeling3dReconstructPreviewListener.cs
@@ -5,8 +5,8 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
 {
     public class Modeling3dReconstructPreviewListener : AndroidJavaProxy
     {
-        //wrapper for com.huawei.hms.objreconstructsdk.cloud.IModeling3dReconstructPreviewListener
-        //https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructdownloadlistener-0000001106613206
+        //wrapper for com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructPreviewListener
+        //https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructpreviewlistener-0000001149001208
 
         private readonly IModeling3dReconstructPreviewListener _IModeling3dReconstructPreviewListener;
 
@@ -15,12 +15,12 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
             _IModeling3dReconstructPreviewListener = IModeling3dReconstructPreviewListener;
         }
 
-        public void onError(String taskId, int errorCode, String errorMsg)
+        public void onError(string taskId, int errorCode, string errorMsg)
         {
             _IModeling3dReconstructPreviewListener.onError(taskId, errorCode, errorMsg);
         }
 
-        public void OnResult(String taskId, AndroidJavaObject javaObject)
+        public void OnResult(string taskId, AndroidJavaObject javaObject)
         {
             _IModeling3dReconstructPreviewListener.OnResult(taskId, javaObject);
         }
@@ -29,9 +29,9 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
 
     public interface IModeling3dReconstructPreviewListener
     {
-        void onError(String taskId, int errorCode, String message);
+        void onError(string taskId, int errorCode, string message);
 
-        void OnResult(String taskId, AndroidJavaObject javaObject);
+        void OnResult(string taskId, AndroidJavaObject javaObject);
 
     }
 }

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Abstract/Modeling3dReconstructUploadListener.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Abstract/Modeling3dReconstructUploadListener.cs
@@ -5,27 +5,27 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
 {
     public class Modeling3dReconstructUploadListener : AndroidJavaProxy
     {
-        //wrapper for com.huawei.hms.objreconstructsdk.cloud.IModeling3dReconstructUploadListener
+        //wrapper for com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructUploadListener
         //https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructuploadlistener-0000001153093115
 
         private readonly IModeling3dReconstructUploadListener _IModeling3dReconstructUploadListener;
 
-        public Modeling3dReconstructUploadListener(IModeling3dReconstructUploadListener IModeling3dReconstructUploadListener) : base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructDownloadListener")
+        public Modeling3dReconstructUploadListener(IModeling3dReconstructUploadListener IModeling3dReconstructUploadListener) : base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructUploadListener")
         {
             _IModeling3dReconstructUploadListener = IModeling3dReconstructUploadListener;
         }
 
-        public void onUploadProgress(String taskId, double progress, AndroidJavaObject javaObject)
+        public void onUploadProgress(string taskId, double progress, AndroidJavaObject javaObject)
         {
             _IModeling3dReconstructUploadListener.onDownloadProgress(taskId, progress, javaObject);
         }
 
-        public void onError(String taskId, int errorCode, String errorMsg)
+        public void onError(string taskId, int errorCode, string errorMsg)
         {
             _IModeling3dReconstructUploadListener.onError(taskId, errorCode, errorMsg);
         }
 
-        public void OnResult(String taskId, Modeling3dReconstructUploadResult result, AndroidJavaObject javaObject)
+        public void OnResult(string taskId, Modeling3dReconstructUploadResult result, AndroidJavaObject javaObject)
         {
             _IModeling3dReconstructUploadListener.OnResult(taskId, result, javaObject);
         }
@@ -35,11 +35,11 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
     public interface IModeling3dReconstructUploadListener
     {
         //JavaObject maybe make problems be careful doing test.
-        void onDownloadProgress(String taskId, double progress, AndroidJavaObject javaObject);
+        void onDownloadProgress(string taskId, double progress, AndroidJavaObject javaObject);
 
-        void onError(String taskId, int errorCode, String errorMessage);
+        void onError(string taskId, int errorCode, string errorMessage);
 
-        void OnResult(String taskId, Modeling3dReconstructUploadResult result, AndroidJavaObject javaObject);
+        void OnResult(string taskId, Modeling3dReconstructUploadResult result, AndroidJavaObject javaObject);
 
     }
 }

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Abstract/Modeling3dReconstructUploadListener.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Abstract/Modeling3dReconstructUploadListener.cs
@@ -25,9 +25,9 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
             _IModeling3dReconstructUploadListener.onError(taskId, errorCode, errorMsg);
         }
 
-        public void OnResult(string taskId, Modeling3dReconstructUploadResult result, AndroidJavaObject javaObject)
+        public void onResult(string taskId, Modeling3dReconstructUploadResult result, AndroidJavaObject javaObject)
         {
-            _IModeling3dReconstructUploadListener.OnResult(taskId, result, javaObject);
+            _IModeling3dReconstructUploadListener.onResult(taskId, result, javaObject);
         }
 
     }
@@ -39,7 +39,7 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
 
         void onError(string taskId, int errorCode, string errorMessage);
 
-        void OnResult(string taskId, Modeling3dReconstructUploadResult result, AndroidJavaObject javaObject);
+        void onResult(string taskId, Modeling3dReconstructUploadResult result, AndroidJavaObject javaObject);
 
     }
 }

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Abstract/Modeling3dReconstructUploadListener.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Abstract/Modeling3dReconstructUploadListener.cs
@@ -17,7 +17,7 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
 
         public void onUploadProgress(string taskId, double progress, AndroidJavaObject javaObject)
         {
-            _IModeling3dReconstructUploadListener.onDownloadProgress(taskId, progress, javaObject);
+            _IModeling3dReconstructUploadListener.onUploadProgress(taskId, progress, javaObject);
         }
 
         public void onError(string taskId, int errorCode, string errorMsg)
@@ -25,9 +25,9 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
             _IModeling3dReconstructUploadListener.onError(taskId, errorCode, errorMsg);
         }
 
-        public void onResult(string taskId, Modeling3dReconstructUploadResult result, AndroidJavaObject javaObject)
+        public void onResult(string taskId, AndroidJavaObject result, AndroidJavaObject javaObject)
         {
-            _IModeling3dReconstructUploadListener.onResult(taskId, result, javaObject);
+            _IModeling3dReconstructUploadListener.onResult(taskId, (Modeling3dReconstructUploadResult)result, javaObject);
         }
 
     }
@@ -35,7 +35,7 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
     public interface IModeling3dReconstructUploadListener
     {
         //JavaObject maybe make problems be careful doing test.
-        void onDownloadProgress(string taskId, double progress, AndroidJavaObject javaObject);
+        void onUploadProgress(string taskId, double progress, AndroidJavaObject javaObject);
 
         void onError(string taskId, int errorCode, string errorMessage);
 

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructDownloadConfig.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructDownloadConfig.cs
@@ -1,0 +1,54 @@
+using System;
+using HuaweiMobileServices.Utils;
+using UnityEngine;
+
+namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
+{
+    //wrapper for com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructDownloadConfig
+    //https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructdownloadconfig-0000001208860367
+    public class Modeling3dReconstructDownloadConfig : JavaObjectWrapper
+    {
+        public Modeling3dReconstructDownloadConfig(String fileFormat, int textureMode) : 
+                                    base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructDownloadConfig", fileFormat, textureMode) { }
+
+        /// <summary>
+        /// Obtains the file format of the downloaded model.
+        /// </summary>
+        /// <returns>File format of the downloaded model. GLTF: glTF format or OBJ: OBJ format</returns>
+        public string ModelFormat => CallAsString("getModelFormat");
+       
+        /// <summary>
+        /// Obtains the texture map mode.
+        /// </summary>
+        /// <returns>Texture map mode. NORMAL: normal mode. PBR: PBR mode.</returns>
+        public int TextureMode => CallAsInt("getTextureMode");
+
+        public class Factory : JavaObjectWrapper
+        {
+            public Factory(AndroidJavaObject javaObject) : base(javaObject) { }
+
+            public Factory() : base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructDownloadConfig$Factory") { }
+
+            /// <summary>
+            /// Sets the model file format.
+            /// </summary>
+            /// <param name="modelFormat">File format of the downloaded model. GLTF: glTF format or OBJ: OBJ format</param>
+            /// <returns>Instance of Modeling3dReconstructDownloadConfig.Factory.</returns>
+            public Factory SetModelFormat(string modelFormat) => CallAsWrapper<Factory>("setModelFormat", modelFormat.AsJavaString());
+
+            /// <summary>
+            /// Sets the texture map mode.
+            /// </summary>
+            /// <param name="textureMode">Texture map mode. NORMAL: normal mode. PBR: PBR mode.</param>
+            /// <returns>Instance of Modeling3dReconstructDownloadConfig.Factory.</returns>
+            public Factory SetTextureMode(int textureMode) => CallAsWrapper<Factory>("setTextureMode", textureMode);
+
+            /// <summary>
+            /// Creates an instance of Modeling3dReconstructDownloadConfig.
+            /// </summary>
+            public Modeling3dReconstructDownloadConfig Create() => CallAsWrapper<Modeling3dReconstructDownloadConfig>("create");
+                
+            
+        }
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructDownloadConfig.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructDownloadConfig.cs
@@ -8,6 +8,7 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
     //https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructdownloadconfig-0000001208860367
     public class Modeling3dReconstructDownloadConfig : JavaObjectWrapper
     {
+        public Modeling3dReconstructDownloadConfig(AndroidJavaObject javaObject) : base(javaObject) { }
         public Modeling3dReconstructDownloadConfig(string fileFormat, int textureMode) : 
                                     base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructDownloadConfig", fileFormat.AsJavaString(), textureMode.AsJavaInteger()){ }
 

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructDownloadConfig.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructDownloadConfig.cs
@@ -8,8 +8,8 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
     //https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructdownloadconfig-0000001208860367
     public class Modeling3dReconstructDownloadConfig : JavaObjectWrapper
     {
-        public Modeling3dReconstructDownloadConfig(String fileFormat, int textureMode) : 
-                                    base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructDownloadConfig", fileFormat, textureMode) { }
+        public Modeling3dReconstructDownloadConfig(string fileFormat, int textureMode) : 
+                                    base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructDownloadConfig", fileFormat.AsJavaString(), textureMode.AsJavaInteger()){ }
 
         /// <summary>
         /// Obtains the file format of the downloaded model.
@@ -41,7 +41,7 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
             /// </summary>
             /// <param name="textureMode">Texture map mode. NORMAL: normal mode. PBR: PBR mode.</param>
             /// <returns>Instance of Modeling3dReconstructDownloadConfig.Factory.</returns>
-            public Factory SetTextureMode(int textureMode) => CallAsWrapper<Factory>("setTextureMode", textureMode);
+            public Factory SetTextureMode(int textureMode) => CallAsWrapper<Factory>("setTextureMode", textureMode.AsJavaInteger());
 
             /// <summary>
             /// Creates an instance of Modeling3dReconstructDownloadConfig.

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructDownloadResult.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructDownloadResult.cs
@@ -9,7 +9,7 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
     public class Modeling3dReconstructDownloadResult : JavaObjectWrapper
     {
         public Modeling3dReconstructDownloadResult(AndroidJavaObject javaObject) : base(javaObject) { }
-        public Modeling3dReconstructDownloadResult(string taskId, bool isComplate) : base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructDownloadResult", taskId, isComplate) { }
+        public Modeling3dReconstructDownloadResult(string taskId, bool isComplete) : base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructDownloadResult", taskId, isComplete) { }
 
         public static explicit operator Modeling3dReconstructDownloadResult(AndroidJavaObject v) => new Modeling3dReconstructDownloadResult(v);
 
@@ -20,8 +20,8 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
         /// <returns>
         /// Model download result. true: The model is downloaded successfully. false: The model fails to be downloaded.
         /// </returns>
-        public bool Complate {
-            get => Call<bool>("isComplate");
+        public bool Complete {
+            get => Call<bool>("isComplete");
             set => Call("setComplate", value);
         }
         /// <summary>

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructDownloadResult.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructDownloadResult.cs
@@ -8,13 +8,7 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
     //https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructdownloadresult-0000001106293440
     public class Modeling3dReconstructDownloadResult : JavaObjectWrapper
     {
-        public Modeling3dReconstructDownloadResult(String taskId, bool isComplate) : base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructDownloadResult", taskId, isComplate) { }
-
-        /// <summary>
-        /// Obtains the ID of a 3D object reconstruction task.
-        /// </summary>
-        /// <returns>ID of a 3D object reconstruction task. A unique task ID is generated each time the 3D object reconstruction API is called.</returns>
-        public string TaskId => CallAsString("getTaskId");
+        public Modeling3dReconstructDownloadResult(string taskId, bool isComplate) : base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructDownloadResult", taskId.AsJavaString(), isComplate) { }
 
         /// <summary>
         /// Obtains the model download result.
@@ -22,13 +16,19 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
         /// <returns>
         /// Model download result. true: The model is downloaded successfully. false: The model fails to be downloaded.
         /// </returns>
-        public bool IsComplate => Call<bool>("isComplate");
+        public bool Complate {
+            get => Call<bool>("isComplate");
+            set => Call("setComplate", value);
+        }
+        /// <summary>
+        /// Obtains the ID of a 3D object reconstruction task.
+        /// </summary>
+        /// <returns>ID of a 3D object reconstruction task. A unique task ID is generated each time the 3D object reconstruction API is called.</returns>
+        public string TaskId
+        {
+            get => CallAsString("getTaskId");
+            set => Call("setTaskId", value.AsJavaString());
+        }
 
-        public void SetTaskId(string taskId) => Call("setTaskId", taskId.AsJavaString());
-
-        public void SetComplate(bool isComplate) => Call("setComplate", isComplate);
-
-
-    
     }
 }

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructDownloadResult.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructDownloadResult.cs
@@ -8,7 +8,11 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
     //https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructdownloadresult-0000001106293440
     public class Modeling3dReconstructDownloadResult : JavaObjectWrapper
     {
-        public Modeling3dReconstructDownloadResult(string taskId, bool isComplate) : base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructDownloadResult", taskId.AsJavaString(), isComplate) { }
+        public Modeling3dReconstructDownloadResult(AndroidJavaObject javaObject) : base(javaObject) { }
+        public Modeling3dReconstructDownloadResult(string taskId, bool isComplate) : base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructDownloadResult", taskId, isComplate) { }
+
+        public static explicit operator Modeling3dReconstructDownloadResult(AndroidJavaObject v) => new Modeling3dReconstructDownloadResult(v);
+
 
         /// <summary>
         /// Obtains the model download result.

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructDownloadResult.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructDownloadResult.cs
@@ -1,0 +1,34 @@
+using System;
+using HuaweiMobileServices.Utils;
+using UnityEngine;
+
+namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
+{
+    //wrapper for com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructDownloadResult
+    //https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructdownloadresult-0000001106293440
+    public class Modeling3dReconstructDownloadResult : JavaObjectWrapper
+    {
+        public Modeling3dReconstructDownloadResult(String taskId, bool isComplate) : base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructDownloadResult", taskId, isComplate) { }
+
+        /// <summary>
+        /// Obtains the ID of a 3D object reconstruction task.
+        /// </summary>
+        /// <returns>ID of a 3D object reconstruction task. A unique task ID is generated each time the 3D object reconstruction API is called.</returns>
+        public string TaskId => CallAsString("getTaskId");
+
+        /// <summary>
+        /// Obtains the model download result.
+        /// </summary>
+        /// <returns>
+        /// Model download result. true: The model is downloaded successfully. false: The model fails to be downloaded.
+        /// </returns>
+        public bool IsComplate => Call<bool>("isComplate");
+
+        public void SetTaskId(string taskId) => Call("setTaskId", taskId.AsJavaString());
+
+        public void SetComplate(bool isComplate) => Call("setComplate", isComplate);
+
+
+    
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructEngine.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructEngine.cs
@@ -33,7 +33,7 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
         /// <param name="taskId">Task ID.</param>
         /// <param name="fileSavePath">Path to which the generated 3D object model is to be saved.</param>
         /// <param name="downloadConfig">Custom download configurations.</param>
-        public void DownloadModelWithConfig(string taskId, string fileSavePath, Modeling3dReconstructDownloadConfig downloadConfig) => Call("downloadModelWithConfig", taskId.AsJavaString(), fileSavePath.AsJavaString(), downloadConfig);
+        public void DownloadModelWithConfig(string taskId, string fileSavePath, Modeling3dReconstructDownloadConfig downloadConfig) => Call("downloadModelWithConfig", taskId, fileSavePath, downloadConfig);
         /// <summary>
         /// Downloads the 3D object reconstruction task result.
         /// </summary>
@@ -48,7 +48,7 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
         /// </summary>
         /// <param name="taskId">Task ID.</param>
         /// <param name="filePath">Path from which images are to be uploaded.</param>
-        public void UploadFile(string taskId, string filePath) => Call("uploadFile", taskId.AsJavaString(), filePath.AsJavaString());
+        public void UploadFile(string taskId, string filePath) => Call("uploadFile", taskId, filePath);
 
     }
 }

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructEngine.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructEngine.cs
@@ -1,0 +1,57 @@
+using System;
+using HuaweiMobileServices.Utils;
+using UnityEngine;
+
+namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
+{
+    //wrapper for com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructEngine
+    //https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructengine-0000001153013003
+    public class Modeling3dReconstructEngine : JavaObjectWrapper
+    {
+        private static AndroidJavaClass sJavaClass = new AndroidJavaClass("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructEngine");
+        public Modeling3dReconstructEngine(AndroidJavaObject javaObject) : base(javaObject) { }
+        /// <summary>
+        /// Obtains a Modeling3dReconstructEngine instance.
+        /// </summary>
+        /// <param name="context">Context.</param>
+        /// <returns>Instance of Modeling3dReconstructEngine.</returns>
+        public Modeling3dReconstructEngine GetInstance(AndroidJavaObject context) => sJavaClass.CallStaticAsWrapper<Modeling3dReconstructEngine>("getInstance",context);
+        /// <summary>
+        /// Initializes a 3D object reconstruction task.
+        /// </summary>
+        /// <param name="setting">3D object reconstruction task settings.</param>
+        /// <returns>Initialization result.</returns>
+        public Modeling3dReconstructEngine InitTask(Modeling3dReconstructSetting setting) => CallAsWrapper<Modeling3dReconstructEngine>("initTask", setting);
+        public int CancelDownload(string taskId) => Call<int>("cancelDownload", taskId.AsJavaString());
+        public int CancelUpload(string taskId) => Call<int>("cancelUpload", taskId.AsJavaString());
+        /// <summary>
+        /// Disables the 3D object reconstruction engine.
+        /// </summary>
+        public void Close() => Call("close");
+        /// <summary>
+        /// Downloads the 3D object reconstruction task result using the custom configuration.
+        /// </summary>
+        /// <param name="taskId">Task ID.</param>
+        /// <param name="fileSavePath">Path to which the generated 3D object model is to be saved.</param>
+        /// <param name="downloadConfig">Custom download configurations.</param>
+        public void DownloadModelWithConfig(string taskId, string fileSavePath, Modeling3dReconstructDownloadConfig downloadConfig) => Call("downloadModelWithConfig", taskId.AsJavaString(), fileSavePath.AsJavaString(), downloadConfig);
+        /// <summary>
+        /// Downloads the 3D object reconstruction task result.
+        /// </summary>
+        /// <param name="taskId">Task ID.</param>
+        /// <param name="context">App context.</param>
+        /// <param name="previewConfig">Preview configuration.</param>
+        /// <param name="previewListener">Listener for the preview.</param>
+        public void PreviewModelWithConfig(string taskId, AndroidJavaObject context, Modeling3dReconstructPreviewConfig previewConfig, Modeling3dReconstructPreviewListener previewListener) => Call("previewModelWithConfig", taskId.AsJavaString(), context, previewConfig, previewListener);
+        public void SetReconstructDownloadListener(Modeling3dReconstructDownloadListener listener) => Call("setReconstructDownloadListener", listener);
+        public void SetReconstructUploadListener(Modeling3dReconstructUploadListener listener) => Call("setReconstructUploadListener", listener);
+       
+        /// <summary>
+        /// Uploads images and triggers a 3D object reconstruction task.
+        /// </summary>
+        /// <param name="taskId">Task ID.</param>
+        /// <param name="filePath">Path from which images are to be uploaded.</param>
+        public void UploadFile(string taskId, string filePath) => Call("uploadFile", taskId.AsJavaString(), filePath.AsJavaString());
+
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructEngine.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructEngine.cs
@@ -20,7 +20,7 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
         /// </summary>
         /// <param name="setting">3D object reconstruction task settings.</param>
         /// <returns>Initialization result.</returns>
-        public Modeling3dReconstructEngine InitTask(Modeling3dReconstructSetting setting) => CallAsWrapper<Modeling3dReconstructEngine>("initTask", setting);
+        public Modeling3dReconstructInitResult InitTask(Modeling3dReconstructSetting setting) => CallAsWrapper<Modeling3dReconstructInitResult>("initTask", setting);
         public int CancelDownload(string taskId) => Call<int>("cancelDownload", taskId.AsJavaString());
         public int CancelUpload(string taskId) => Call<int>("cancelUpload", taskId.AsJavaString());
         /// <summary>

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructEngine.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructEngine.cs
@@ -21,8 +21,8 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
         /// <param name="setting">3D object reconstruction task settings.</param>
         /// <returns>Initialization result.</returns>
         public Modeling3dReconstructInitResult InitTask(Modeling3dReconstructSetting setting) => CallAsWrapper<Modeling3dReconstructInitResult>("initTask", setting);
-        public int CancelDownload(string taskId) => Call<int>("cancelDownload", taskId.AsJavaString());
-        public int CancelUpload(string taskId) => Call<int>("cancelUpload", taskId.AsJavaString());
+        public int CancelDownload(string taskId) => Call<int>("cancelDownload", taskId);
+        public int CancelUpload(string taskId) => Call<int>("cancelUpload", taskId);
         /// <summary>
         /// Disables the 3D object reconstruction engine.
         /// </summary>

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructEngine.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructEngine.cs
@@ -14,7 +14,7 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
         /// Obtains a Modeling3dReconstructEngine instance.
         /// </summary>
         /// <returns>Instance of Modeling3dReconstructEngine.</returns>
-        public Modeling3dReconstructEngine GetInstance() => sJavaClass.CallStaticAsWrapper<Modeling3dReconstructEngine>("getInstance",AndroidContext.ApplicationContext);
+        public static Modeling3dReconstructEngine GetInstance() => sJavaClass.CallStaticAsWrapper<Modeling3dReconstructEngine>("getInstance",AndroidContext.ApplicationContext);
         /// <summary>
         /// Initializes a 3D object reconstruction task.
         /// </summary>
@@ -42,8 +42,7 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
         /// <param name="previewListener">Listener for the preview.</param>
         public void PreviewModelWithConfig(string taskId, Modeling3dReconstructPreviewConfig previewConfig, Modeling3dReconstructPreviewListener previewListener) => Call("previewModelWithConfig", taskId.AsJavaString(), AndroidContext.ApplicationContext, previewConfig, previewListener);
         public void SetReconstructDownloadListener(Modeling3dReconstructDownloadListener listener) => Call("setReconstructDownloadListener", listener);
-        public void SetReconstructUploadListener(Modeling3dReconstructUploadListener listener) => Call("setReconstructUploadListener", listener);
-       
+        public void SetReconstructUploadListener(Modeling3dReconstructUploadListener listener) => Call("setReconstructUploadListener", listener);  
         /// <summary>
         /// Uploads images and triggers a 3D object reconstruction task.
         /// </summary>

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructEngine.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructEngine.cs
@@ -13,9 +13,8 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
         /// <summary>
         /// Obtains a Modeling3dReconstructEngine instance.
         /// </summary>
-        /// <param name="context">Context.</param>
         /// <returns>Instance of Modeling3dReconstructEngine.</returns>
-        public Modeling3dReconstructEngine GetInstance(AndroidJavaObject context) => sJavaClass.CallStaticAsWrapper<Modeling3dReconstructEngine>("getInstance",context);
+        public Modeling3dReconstructEngine GetInstance() => sJavaClass.CallStaticAsWrapper<Modeling3dReconstructEngine>("getInstance",AndroidContext.ApplicationContext);
         /// <summary>
         /// Initializes a 3D object reconstruction task.
         /// </summary>
@@ -39,10 +38,9 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
         /// Downloads the 3D object reconstruction task result.
         /// </summary>
         /// <param name="taskId">Task ID.</param>
-        /// <param name="context">App context.</param>
         /// <param name="previewConfig">Preview configuration.</param>
         /// <param name="previewListener">Listener for the preview.</param>
-        public void PreviewModelWithConfig(string taskId, AndroidJavaObject context, Modeling3dReconstructPreviewConfig previewConfig, Modeling3dReconstructPreviewListener previewListener) => Call("previewModelWithConfig", taskId.AsJavaString(), context, previewConfig, previewListener);
+        public void PreviewModelWithConfig(string taskId, Modeling3dReconstructPreviewConfig previewConfig, Modeling3dReconstructPreviewListener previewListener) => Call("previewModelWithConfig", taskId.AsJavaString(), AndroidContext.ApplicationContext, previewConfig, previewListener);
         public void SetReconstructDownloadListener(Modeling3dReconstructDownloadListener listener) => Call("setReconstructDownloadListener", listener);
         public void SetReconstructUploadListener(Modeling3dReconstructUploadListener listener) => Call("setReconstructUploadListener", listener);
        

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructInitResult.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructInitResult.cs
@@ -1,0 +1,41 @@
+using System;
+using HuaweiMobileServices.Utils;
+using UnityEngine;
+
+namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
+{
+    
+    //wrapper for com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructInitResult
+    //https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructinitresult-0000001106773056
+    public class Modeling3dReconstructInitResult : JavaObjectWrapper
+    {
+        public Modeling3dReconstructInitResult(String taskId, int retCode, String retMsg) : 
+                            base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructInitResult", taskId, retCode, retMsg) { }
+        
+
+        /// <summary>
+        /// Obtains the ID of a 3D object reconstruction task.
+        /// </summary>
+        /// <returns>ID of a 3D object reconstruction task. A unique task ID is generated each time the 3D object reconstruction API is called.</returns>
+        public string TaskId => CallAsString("getTaskId");
+
+        /// <summary>
+        /// Obtains the result code of a 3D object reconstruction task.
+        /// </summary>
+        /// <returns>
+        /// Result code of a 3D object reconstruction task. 0: The task is initialized successfully. 1: The task fails to be initialized.
+        /// </returns>
+        public int RetCode => Call<int>("getRetCode");
+
+
+        /// <summary>
+        /// Obtains the result message of a 3D object reconstruction task.
+        /// </summary>
+        /// <returns>   
+        /// Result message of a 3D object reconstruction task. The result message is returned when the task fails to be initialized.
+        /// </returns>
+        public string RetMsg => CallAsString("getRetMsg");
+        
+
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructInitResult.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructInitResult.cs
@@ -9,8 +9,8 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
     //https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructinitresult-0000001106773056
     public class Modeling3dReconstructInitResult : JavaObjectWrapper
     {
-        public Modeling3dReconstructInitResult(String taskId, int retCode, String retMsg) : 
-                            base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructInitResult", taskId, retCode, retMsg) { }
+        public Modeling3dReconstructInitResult(string taskId, int retCode, string retMsg) : 
+                            base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructInitResult", taskId.AsJavaString(), retCode, retMsg.AsJavaString()) { }
         
 
         /// <summary>
@@ -26,7 +26,6 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
         /// Result code of a 3D object reconstruction task. 0: The task is initialized successfully. 1: The task fails to be initialized.
         /// </returns>
         public int RetCode => Call<int>("getRetCode");
-
 
         /// <summary>
         /// Obtains the result message of a 3D object reconstruction task.

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructInitResult.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructInitResult.cs
@@ -9,6 +9,7 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
     //https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructinitresult-0000001106773056
     public class Modeling3dReconstructInitResult : JavaObjectWrapper
     {
+        public Modeling3dReconstructInitResult(AndroidJavaObject javaObject) : base(javaObject) { }
         public Modeling3dReconstructInitResult(string taskId, int retCode, string retMsg) : 
                             base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructInitResult", taskId.AsJavaString(), retCode, retMsg.AsJavaString()) { }
         

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructPreviewConfig.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructPreviewConfig.cs
@@ -1,0 +1,29 @@
+using System;
+using HuaweiMobileServices.Utils;
+using UnityEngine;
+
+namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
+{
+    
+    //wrapper for com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructPreviewConfig
+    //https://developer.huawei.com/consumer/en/doc/development/graphics-References/previewconfig-0000001186461516
+    public class Modeling3dReconstructPreviewConfig : JavaObjectWrapper
+    {
+        public Modeling3dReconstructPreviewConfig(AndroidJavaObject javaObject) : base(javaObject) { }
+
+        public Modeling3dReconstructPreviewConfig(int textureMode) : base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructPreviewConfig", textureMode.AsJavaInteger()) { }
+
+        public int TextureMode => CallAsInt("getTextureMode");
+
+        public class Factory : JavaObjectWrapper
+        {
+            public Factory(AndroidJavaObject javaObject) : base(javaObject) { }
+
+            public Factory() : base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructPreviewConfig$Factory") { }
+
+            public Factory SetTextureMode(int textureMode) => CallAsWrapper<Factory>("setTextureMode", textureMode.AsJavaInteger());
+            public Modeling3dReconstructPreviewConfig Create() => CallAsWrapper<Modeling3dReconstructPreviewConfig>("create");
+        }
+
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructQueryResult.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructQueryResult.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using HuaweiMobileServices.Utils;
+using UnityEngine;
+
+namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
+{
+    
+    //wrapper for com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructQueryResult
+    //https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructqueryresult-0000001152893165
+    public class Modeling3dReconstructQueryResult : JavaObjectWrapper
+    {
+        public Modeling3dReconstructQueryResult(AndroidJavaObject javaObject) : base(javaObject) { }
+
+        public Modeling3dReconstructQueryResult(string taskId, int retCode, string redMsg) : base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructQueryResult", taskId.AsJavaString(), retCode, redMsg.AsJavaString()) { }
+
+        /// <summary>
+        /// Obtains the supported model file formats.
+        /// </summary>
+        public IList<string> GetModelFormat() => Call<AndroidJavaObject>("getModelFormat").AsStringList();
+        /// <summary>
+        /// Obtains the reason why the 3D object reconstruction task fails.
+        /// </summary>
+        /// <returns>Failure reason.</returns>
+        public string GetReconstructFailMessage() => CallAsString("getReconstructFailMessage");
+        /// <summary>
+        /// Obtains the result code for a 3D object reconstruction task.
+        /// </summary>
+        /// <returns>Result code.</returns>
+        public int GetRetCode() => Call<int>("getRetCode");
+        /// <summary>
+        /// Obtains the description of the result code for a 3D object reconstruction task.
+        /// </summary>
+        /// <returns>Description of the result code.</returns>
+        public string GetRetMessage() => CallAsString("getRetMessage");
+        /// <summary>
+        /// Obtains the status of a 3D object reconstruction task.
+        /// </summary>
+        /// <returns>Status of a 3D object reconstruction task. <see cref="Status Link:" href=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructconstants-progressstatus-0000001153213065" /></returns>
+        public string GetStatus() => CallAsString("getStatus");
+        /// <summary>
+        /// Obtains the task ID of a 3D object reconstruction task.
+        /// </summary>
+        /// <returns>ID of a 3D object reconstruction task. A unique task ID is generated each time the 3D object reconstruction API is called.</returns> 
+        public string GetTaskId() => CallAsString("getTaskId");
+
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructQueryResult.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructQueryResult.cs
@@ -22,27 +22,27 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
         /// Obtains the reason why the 3D object reconstruction task fails.
         /// </summary>
         /// <returns>Failure reason.</returns>
-        public string GetReconstructFailMessage() => CallAsString("getReconstructFailMessage");
+        public string ReconstructFailMessage => CallAsString("getReconstructFailMessage");
         /// <summary>
         /// Obtains the result code for a 3D object reconstruction task.
         /// </summary>
         /// <returns>Result code.</returns>
-        public int GetRetCode() => Call<int>("getRetCode");
+        public int RetCode => Call<int>("getRetCode");
         /// <summary>
         /// Obtains the description of the result code for a 3D object reconstruction task.
         /// </summary>
         /// <returns>Description of the result code.</returns>
-        public string GetRetMessage() => CallAsString("getRetMessage");
+        public string RetMessage => CallAsString("getRetMessage");
         /// <summary>
         /// Obtains the status of a 3D object reconstruction task.
         /// </summary>
         /// <returns>Status of a 3D object reconstruction task. <see cref="Status Link:" href=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructconstants-progressstatus-0000001153213065" /></returns>
-        public string GetStatus() => CallAsString("getStatus");
+        public int Status => Call<int>("getStatus");
         /// <summary>
         /// Obtains the task ID of a 3D object reconstruction task.
         /// </summary>
         /// <returns>ID of a 3D object reconstruction task. A unique task ID is generated each time the 3D object reconstruction API is called.</returns> 
-        public string GetTaskId() => CallAsString("getTaskId");
+        public string TaskId => CallAsString("getTaskId");
 
     }
 }

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructSetting.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructSetting.cs
@@ -1,0 +1,75 @@
+using System;
+using HuaweiMobileServices.Utils;
+using UnityEngine;
+
+namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
+{
+    //wrapper for com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructSetting
+    //https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructsetting-0000001153013005
+    public class Modeling3dReconstructSetting : JavaObjectWrapper
+    {
+        //private static AndroidJavaClass sJavaClass = new AndroidJavaClass("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructSetting");
+        public Modeling3dReconstructSetting(AndroidJavaObject javaObject) : base(javaObject) { }
+        public Modeling3dReconstructSetting(int mode) : base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructSetting", mode.AsJavaInteger()) { }
+        public Modeling3dReconstructSetting(int mode, int textureMode) : 
+                base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructSetting", mode.AsJavaInteger(), textureMode.AsJavaInteger()) { }
+        public Modeling3dReconstructSetting(int mode, int textureMode, int taskType) : 
+                base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructSetting", mode.AsJavaInteger(), textureMode.AsJavaInteger(), taskType.AsJavaInteger()) { }
+        public Modeling3dReconstructSetting(int mode, int textureMode, int taskType, string needRescan) : 
+                base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructSetting",  mode.AsJavaInteger(), textureMode.AsJavaInteger(), taskType.AsJavaInteger(),needRescan.AsJavaString()) { }
+        public Modeling3dReconstructSetting(int mode, int textureMode, int taskType, string needRescan, string taskId) : 
+                base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructSetting", mode.AsJavaInteger(), textureMode.AsJavaInteger(), taskType.AsJavaInteger(),needRescan.AsJavaString(),taskId.AsJavaString()) { }
+        public Modeling3dReconstructSetting(int mode, int textureMode, int taskType, string needRescan, string taskId, int faceLevel) : 
+                base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructSetting", mode.AsJavaInteger(), textureMode.AsJavaInteger(), taskType.AsJavaInteger(),needRescan.AsJavaString(),taskId.AsJavaString(), faceLevel.AsJavaInteger()) { }
+
+        public int GetFaceLevel() => CallAsInt("getFaceLevel");
+        public void SetFaceLevel(int faceLevel) => Call("setFaceLevel", faceLevel.AsJavaInteger());
+        /// <summary>
+        /// Obtains the type of a 3D object reconstruction task.
+        /// </summary>
+        /// <returns>	
+        ///    Type of a 3D object reconstruction task.
+        ///    AUTO_RIGGING: auto rigging
+        ///    OBJ_RECONSTRUCT: 3D object reconstruction
+        /// </returns>
+        public int GetTaskType() => CallAsInt("getTaskType");
+        /// <summary>
+        /// Obtains the texture map mode.
+        /// </summary>
+        /// <returns> 
+        ///     Texture map mode.
+        ///     NORMAL: normal mode
+        ///     PBR: PBR mode
+        /// </returns>
+        public int GetTextureMode() => CallAsInt("getTextureMode");
+        /// <summary>
+        /// Obtains the working mode for 3D object reconstruction.
+        /// </summary>
+        /// <returns>Working mode.PICTURE: picture mode. Currently, only this mode is supported. <see cref="Status Link:" href=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/capturemode-0000001117263174#section127055371184" /></returns>
+        public int GetReconstructMode() => CallAsInt("getReconstructMode");
+        public string GetNeedRescan() => CallAsString("getNeedRescan");
+        public string GetTaskId() => CallAsString("getTaskId");
+
+        public class Factory : JavaObjectWrapper
+        {
+            public Factory(AndroidJavaObject javaObject) : base(javaObject) { }
+            public Factory() : base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructSetting$Factory") { }
+
+            public Factory SetReconstructMode(int mode) => CallAsWrapper<Factory>("setReconstructMode", mode.AsJavaInteger());
+
+            public Factory SetTextureMode(int textureMode) => CallAsWrapper<Factory>("setTextureMode", textureMode.AsJavaInteger());
+
+            public Factory SetTaskType(int taskType) => CallAsWrapper<Factory>("setTaskType", taskType.AsJavaInteger());
+
+            public Factory SetNeedRescan(string needRescan) => CallAsWrapper<Factory>("setNeedRescan", needRescan.AsJavaString());
+
+            public Factory SetTaskId(string taskId) => CallAsWrapper<Factory>("setTaskId", taskId.AsJavaString());
+
+            public Factory SetFaceLevel(int faceLevel) => CallAsWrapper<Factory>("setFaceLevel", faceLevel.AsJavaInteger());
+
+            public Modeling3dReconstructSetting Create() => CallAsWrapper<Modeling3dReconstructSetting>("create");
+
+        }
+    }
+
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructSetting.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructSetting.cs
@@ -1,4 +1,3 @@
-using System;
 using HuaweiMobileServices.Utils;
 using UnityEngine;
 
@@ -10,9 +9,6 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
     {
         //private static AndroidJavaClass sJavaClass = new AndroidJavaClass("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructSetting");
         public Modeling3dReconstructSetting(AndroidJavaObject javaObject) : base(javaObject) { }
-        public Modeling3dReconstructSetting(int mode) : base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructSetting", mode.AsJavaInteger()) { }
-        public Modeling3dReconstructSetting(int mode, int textureMode) : 
-                base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructSetting", mode.AsJavaInteger(), textureMode.AsJavaInteger()) { }
         public Modeling3dReconstructSetting(int mode, int textureMode, int taskType) : 
                 base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructSetting", mode.AsJavaInteger(), textureMode.AsJavaInteger(), taskType.AsJavaInteger()) { }
         public Modeling3dReconstructSetting(int mode, int textureMode, int taskType, string needRescan) : 
@@ -22,8 +18,12 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
         public Modeling3dReconstructSetting(int mode, int textureMode, int taskType, string needRescan, string taskId, int faceLevel) : 
                 base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructSetting", mode.AsJavaInteger(), textureMode.AsJavaInteger(), taskType.AsJavaInteger(),needRescan.AsJavaString(),taskId.AsJavaString(), faceLevel.AsJavaInteger()) { }
 
-        public int GetFaceLevel() => CallAsInt("getFaceLevel");
-        public void SetFaceLevel(int faceLevel) => Call("setFaceLevel", faceLevel.AsJavaInteger());
+        public int FaceLevel
+        {
+            get => CallAsInt("getFaceLevel");
+            set => Call("setFaceLevel", value.AsJavaInteger());
+        }
+
         /// <summary>
         /// Obtains the type of a 3D object reconstruction task.
         /// </summary>

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructSetting.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructSetting.cs
@@ -32,7 +32,7 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
         ///    AUTO_RIGGING: auto rigging
         ///    OBJ_RECONSTRUCT: 3D object reconstruction
         /// </returns>
-        public int GetTaskType() => CallAsInt("getTaskType");
+        public int TaskType => CallAsInt("getTaskType");
         /// <summary>
         /// Obtains the texture map mode.
         /// </summary>
@@ -41,14 +41,14 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
         ///     NORMAL: normal mode
         ///     PBR: PBR mode
         /// </returns>
-        public int GetTextureMode() => CallAsInt("getTextureMode");
+        public int TextureMode => CallAsInt("getTextureMode");
         /// <summary>
         /// Obtains the working mode for 3D object reconstruction.
         /// </summary>
         /// <returns>Working mode.PICTURE: picture mode. Currently, only this mode is supported. <see cref="Status Link:" href=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/capturemode-0000001117263174#section127055371184" /></returns>
-        public int GetReconstructMode() => CallAsInt("getReconstructMode");
-        public string GetNeedRescan() => CallAsString("getNeedRescan");
-        public string GetTaskId() => CallAsString("getTaskId");
+        public int ReconstructMode => CallAsInt("getReconstructMode");
+        public string NeedRescan => CallAsString("getNeedRescan");
+        public string TaskId => CallAsString("getTaskId");
 
         public class Factory : JavaObjectWrapper
         {

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructTaskUtils.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructTaskUtils.cs
@@ -1,0 +1,46 @@
+
+using System;
+using HuaweiMobileServices.Utils;
+using UnityEngine;
+
+namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
+{
+    //wrapper for com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructTaskUtils
+    //https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructtaskutils-0000001153213069
+    public class Modeling3dReconstructTaskUtils : JavaObjectWrapper
+    {
+        public Modeling3dReconstructTaskUtils(AndroidJavaObject javaObject) : base(javaObject) { }
+
+        private static readonly AndroidJavaClass javaClass = new AndroidJavaClass("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructTaskUtils");
+
+        public Modeling3dReconstructTaskUtils GetInstance() => javaClass.CallStaticAsWrapper<Modeling3dReconstructTaskUtils>("getInstance",AndroidContext.ApplicationContext);
+
+        public int DeleteTask(string taskId) => Call<int>("deleteTask", taskId.AsJavaString());
+        
+        /// <summary>
+        /// Queries the status of a 3D object reconstruction task.
+        /// </summary>
+        /// <param name="taskId">Task ID.</param>
+        /// <returns>Query result.</returns>
+        public Modeling3dReconstructQueryResult QueryTask(string taskId) => CallAsWrapper<Modeling3dReconstructQueryResult>("queryTask", taskId.AsJavaString());
+
+        /// <summary>
+        /// Queries the restriction status of a 3D object reconstruction task using its ID.
+        /// </summary>
+        /// <param name="taskId">Task ID.</param>
+        /// <returns>
+        /// Restriction status. 0 indicates that the task is not restricted. 1 indicates that the task is restricted. Other values indicate a query failure.
+        /// <see cref="Other values:" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/error-code-0000001153097761"/>
+        /// </returns>
+        public int QueryTaskRestrictStatus(string taskId) => Call<int>("queryTaskRestrictStatus", taskId.AsJavaString());
+
+        /// <summary>
+        /// Sets the restriction status of a 3D object reconstruction task using its ID.
+        /// </summary>
+        /// <param name="taskId">Task ID.</param>
+        /// <param name="restrictStatus"Restriction status.</param>"
+        /// <returns> Restriction status setting result. 0 indicates success, and other values indicate failure. </returns>
+        public int SetTaskRestrictStatus(string taskId, int restrictStatus) => Call<int>("setTaskRestrictStatus", taskId.AsJavaString(), restrictStatus);
+
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructTaskUtils.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructTaskUtils.cs
@@ -13,7 +13,7 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
 
         private static readonly AndroidJavaClass javaClass = new AndroidJavaClass("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructTaskUtils");
 
-        public Modeling3dReconstructTaskUtils GetInstance() => javaClass.CallStaticAsWrapper<Modeling3dReconstructTaskUtils>("getInstance",AndroidContext.ApplicationContext);
+        public static Modeling3dReconstructTaskUtils GetInstance() => javaClass.CallStaticAsWrapper<Modeling3dReconstructTaskUtils>("getInstance",AndroidContext.ApplicationContext);
 
         public int DeleteTask(string taskId) => Call<int>("deleteTask", taskId.AsJavaString());
         

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructUploadResult.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructUploadResult.cs
@@ -14,20 +14,22 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
         /// Obtains the ID of a 3D object reconstruction task.
         /// </summary>
         /// <returns>ID of a 3D object reconstruction task. A unique task ID is generated each time the 3D object reconstruction API is called.</returns>
-        public string TaskId => CallAsString("getTaskId");
+        public string TaskId
+        {
+            get => CallAsString("getTaskId");
+            set => Call("setTaskId", value.AsJavaString());
+        }
         /// <summary>
         /// Obtains the model download result.
         /// </summary>
         /// <returns>
         /// Model download result. true: The model is downloaded successfully. false: The model fails to be downloaded.
         /// </returns>
-        public bool IsComplate => Call<bool>("isComplate");
+        public bool Complate
+        {
+            get => Call<bool>("isComplate");
+            set => Call("setComplate", value);
+        }
 
-        public void SetTaskId(string taskId) => Call("setTaskId", taskId.AsJavaString());
-
-        public void SetComplate(bool isComplate) => Call("setComplate", isComplate);
-
-
-    
     }
 }

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructUploadResult.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructUploadResult.cs
@@ -1,0 +1,33 @@
+using System;
+using HuaweiMobileServices.Utils;
+using UnityEngine;
+
+namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
+{
+    //wrapper for com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructUploadResult
+    //https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructuploadresult-0000001106453244
+    public class Modeling3dReconstructUploadResult : JavaObjectWrapper
+    {
+        public Modeling3dReconstructUploadResult(string taskId, bool isComplate) : base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructUploadResult", taskId.AsJavaString(), isComplate) { }
+
+        /// <summary>
+        /// Obtains the ID of a 3D object reconstruction task.
+        /// </summary>
+        /// <returns>ID of a 3D object reconstruction task. A unique task ID is generated each time the 3D object reconstruction API is called.</returns>
+        public string TaskId => CallAsString("getTaskId");
+        /// <summary>
+        /// Obtains the model download result.
+        /// </summary>
+        /// <returns>
+        /// Model download result. true: The model is downloaded successfully. false: The model fails to be downloaded.
+        /// </returns>
+        public bool IsComplate => Call<bool>("isComplate");
+
+        public void SetTaskId(string taskId) => Call("setTaskId", taskId.AsJavaString());
+
+        public void SetComplate(bool isComplate) => Call("setComplate", isComplate);
+
+
+    
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructUploadResult.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructUploadResult.cs
@@ -11,7 +11,7 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
     {
         public Modeling3dReconstructUploadResult(AndroidJavaObject javaObject) : base(javaObject) { }
 
-        public Modeling3dReconstructUploadResult(string taskId, bool isComplate) : base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructUploadResult", taskId, isComplate) { }
+        public Modeling3dReconstructUploadResult(string taskId, bool isComplete) : base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructUploadResult", taskId, isComplete) { }
 
         public static explicit operator Modeling3dReconstructUploadResult(AndroidJavaObject v) => new Modeling3dReconstructUploadResult(v);
 

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructUploadResult.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Modeling3dReconstructUploadResult.cs
@@ -1,4 +1,5 @@
 using System;
+using HuaweiMobileServices.Ads.NativeAd;
 using HuaweiMobileServices.Utils;
 using UnityEngine;
 
@@ -8,7 +9,11 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
     //https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructuploadresult-0000001106453244
     public class Modeling3dReconstructUploadResult : JavaObjectWrapper
     {
-        public Modeling3dReconstructUploadResult(string taskId, bool isComplate) : base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructUploadResult", taskId.AsJavaString(), isComplate) { }
+        public Modeling3dReconstructUploadResult(AndroidJavaObject javaObject) : base(javaObject) { }
+
+        public Modeling3dReconstructUploadResult(string taskId, bool isComplate) : base("com.huawei.hms.objreconstructsdk.cloud.Modeling3dReconstructUploadResult", taskId, isComplate) { }
+
+        public static explicit operator Modeling3dReconstructUploadResult(AndroidJavaObject v) => new Modeling3dReconstructUploadResult(v);
 
         /// <summary>
         /// Obtains the ID of a 3D object reconstruction task.
@@ -17,7 +22,7 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
         public string TaskId
         {
             get => CallAsString("getTaskId");
-            set => Call("setTaskId", value.AsJavaString());
+            set => Call("setTaskId", value);
         }
         /// <summary>
         /// Obtains the model download result.
@@ -27,7 +32,7 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud
         /// </returns>
         public bool Complate
         {
-            get => Call<bool>("isComplate");
+            get => Call<bool>("isComplete");
             set => Call("setComplate", value);
         }
 

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Rebody/TaskImageInfo.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Rebody/TaskImageInfo.cs
@@ -1,0 +1,82 @@
+﻿using HuaweiMobileServices.Utils;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud.Rebody
+{
+    /// <summary>
+    /// Information about the images uploaded for a 3D object reconstruction task.
+    /// Wrapper for com.huawei.hms.objreconstructsdk.cloud.rebody.TaskImageInfo.
+    /// <see cref="TaskImageInfo" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/cloud-rebody-taskimageinfo-0000001485324790"/>
+    /// </summary>
+    public class TaskImageInfo : JavaObjectWrapper
+    {
+        public TaskImageInfo(AndroidJavaObject javaObject) : base(javaObject) { }
+
+        //private static readonly AndroidJavaClass javaClass = new AndroidJavaClass("com.huawei.hms.objreconstructsdk.cloud.rebody.TaskImageInfo");
+
+        /// <summary>
+        /// Obtains the size of images.
+        /// </summary>
+        public long Size
+        {
+            get => CallAsLong("getSize") ?? 0;
+            set => Call("setSize", value.AsJavaLong());
+        }
+        /// <summary>
+        /// Obtains the number of images.
+        /// </summary>
+        public int ImageNum
+        {
+            get => CallAsInt("getNum");
+            set => Call("setNum", value.AsJavaInteger());
+        }
+        /// <summary>
+        /// Obtains the format of images.
+        /// </summary>
+        public string Format
+        {
+            get => CallAsString("getFormat");
+            set => Call("setFormat", value.AsJavaString());
+        }
+        /// <summary>
+        /// Resolution for the images.(in pixels)
+        /// </summary>
+        public ImageResolution imageResolation
+        {
+            get => CallAsWrapper<ImageResolution>("getImageResolution");
+            set => Call("setImageResolution", value);
+        }
+
+
+        /// <summary>
+        /// Resolution information about the images uploaded for a 3D object reconstruction task.
+        /// </summary>
+        public class ImageResolution : JavaObjectWrapper
+        {
+            public ImageResolution(AndroidJavaObject javaObject) : base(javaObject) { }
+
+
+            public ImageResolution() : base("com.huawei.hms.objreconstructsdk.cloud.rebody.TaskImageInfo$ImageResolution") { }
+            /// <summary>
+            /// Obtains the width of images uploaded for a 3D object reconstruction task.
+            /// </summary>
+            public int Width
+            {
+                get => Call<int>("getWidth");
+                set => Call("setWidth", value);
+            }
+            /// <summary>
+            /// Obtains the height of images uploaded for a 3D object reconstruction task.
+            /// </summary>
+            public int Height
+            {
+                get => Call<int>("getHeight");
+                set => Call("setHeight", value);
+            }
+
+
+        }
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Rebody/TaskRelationMeta.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Cloud/Rebody/TaskRelationMeta.cs
@@ -1,0 +1,74 @@
+﻿using HuaweiMobileServices.Utils;
+using UnityEngine;
+
+namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk.Cloud.Rebody
+{
+    /// <summary>
+    /// Information about the relationship between a 3D object reconstruction task and other tasks, storing the data of the original task and extra scanning tasks.
+    /// Wrapper for com.huawei.hms.objreconstructsdk.cloud.rebody.TaskRelationMeta.
+    /// <see cref="TaskRelationMeta" link=" https://developer.huawei.com/consumer/en/doc/development/graphics-References/cloud-rebody-taskrelationmeta-0000001536004797"/>
+    /// </summary>
+    public class TaskRelationMeta : JavaObjectWrapper
+    {
+        public TaskRelationMeta(AndroidJavaObject javaObject) : base(javaObject) { }
+        /// <summary>
+        /// Obtains the information about the first extra scanning task for 3D object reconstruction.
+        /// </summary>
+        public RescanTask FirstRescanTask
+        {
+            get => CallAsWrapper<RescanTask>("getFirstRescanTask");
+            set => Call("setFirstRescanTask", value);
+        }
+        /// <summary>
+        /// Obtains the information about the original task for 3D object reconstruction.
+        /// </summary>
+        public RescanTask OriginalTask
+        {
+            get => CallAsWrapper<RescanTask>("getOriginalTask");
+            set => Call("setOriginalTask", value);
+        }
+        /// <summary>
+        /// Obtains the information about the second extra scanning task for 3D object reconstruction.
+        /// </summary>
+        public RescanTask SecondRescanTask
+        {
+            get => CallAsWrapper<RescanTask>("getSecondRescanTask");
+            set => Call("setSecondRescanTask", value);
+        }
+
+        /// <summary>
+        /// Description of a 3D object reconstruction task.
+        /// </summary>
+        public class RescanTask : JavaObjectWrapper
+        {
+            public RescanTask(AndroidJavaObject javaObject) : base(javaObject) { }
+            public RescanTask() : base("com.huawei.hms.objreconstructsdk.cloud.rebody.TaskRelationMeta$RescanTask") { }
+            /// <summary>
+            /// Obtains the ID of the original task.
+            /// </summary>
+            /// <returns>ID of the original task. If the current task is an extra scanning task, this ID belongs to the original task corresponding to the extra scanning task. If the current task is the original task, the value is 0.</returns>
+            public string BaseTaskId
+            {
+                get => CallAsString("getBaseTaskId");
+                set => Call("setBaseTaskId", value.AsJavaString());
+            }
+            /// <summary>
+            /// Obtains the ID of the current task.
+            /// </summary>
+            public string TaskId
+            {
+                get => CallAsString("getTaskId");
+                set => Call("setTaskId", value.AsJavaString());
+            }
+            /// <summary>
+            /// Obtains the information about the uploaded images for the current task.
+            /// </summary>
+            public TaskImageInfo UploadImageInfo
+            {
+                get => CallAsWrapper<TaskImageInfo>("getUploadImageInfo");
+                set => Call("setUploadImageInfo", value);
+            }
+
+        }
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Modeling3dReconstructConstants.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Modeling3dReconstructConstants.cs
@@ -12,7 +12,6 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk
         public Modeling3dReconstructConstants(AndroidJavaObject javaObject) : base(javaObject)
         {
         }
-        public static explicit operator Modeling3dReconstructConstants(AndroidJavaObject javaObject) => javaObject == null ? null : new Modeling3dReconstructConstants(javaObject);
 
         /// <summary>
         /// Reason for a failed 3D object reconstruction task, which is specified in Modeling3dReconstructConstants.
@@ -20,43 +19,46 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk
         public class ReconstructFailCode : JavaObjectWrapper
         {
             //Not necessary to implement this because class name is the same as the java class name
-            //private static AndroidJavaClass sJavaClass = new AndroidJavaClass("com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants");
+
+            private const string CLASS_NAME = "com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$ReconstructFailCode";
+
+            private static AndroidJavaClass sJavaClass = new AndroidJavaClass(CLASS_NAME);
             public ReconstructFailCode(AndroidJavaObject javaObject) : base(javaObject) { }
 
-            public ReconstructFailCode() : base("com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$ReconstructFailCode", AndroidContext.ActivityContext) { }
+            public ReconstructFailCode() : base(CLASS_NAME, AndroidContext.ActivityContext) { }
 
             /// <summary>
             /// Internal error.
             /// <returns>Error code = 1 </returns>
             /// </summary>
-            public int INNER_ERROR => CallStatic<int>("INNER_ERROR");
+            public static int INNER_ERROR => sJavaClass.GetStatic<int>("INNER_ERROR");
             /// <summary>
             /// Image file verification failed.
             /// <returns>Error code = 2 </returns>
             /// </summary>
-            public int FILE_CHECK_FAILED => CallStatic<int>("FILE_CHECK_FAILED");
+            public static int FILE_CHECK_FAILED => sJavaClass.GetStatic<int>("FILE_CHECK_FAILED");
             /// <summary>
             /// Invalid image.
             /// </summary>
             /// <returns>Error code = 3 </returns>
-            public int PICTURE_ILLEGAL => CallStatic<int>("PICTURE_ILLEGAL");
+            public static int PICTURE_ILLEGAL => sJavaClass.GetStatic<int>("PICTURE_ILLEGAL");
             /// <summary>
             /// The algorithm processing failed.
             /// </summary>
             /// <returns>Error code = 4 </returns>s
-            public int ALGORITHM_FAILED => CallStatic<int>("ALGORITHM_FAILED");
+            public static int ALGORITHM_FAILED => sJavaClass.GetStatic<int>("ALGORITHM_FAILED");
             /// <summary>
             /// The quota of API calls is used up.
             /// </summary>
             /// <returns>Error code = 5 </returns>
-            public int BILLING_QUOTA_EXHAUSTED => CallStatic<int>("BILLING_QUOTA_EXHAUSTED");
+            public static int BILLING_QUOTA_EXHAUSTED => sJavaClass.GetStatic<int>("BILLING_QUOTA_EXHAUSTED");
             /// <summary>
             /// The project is in arrears.
             /// </summary>
             /// <returns>Error code = 6 </returns>
-            public int BILLING_OVERDUE => CallStatic<int>("BILLING_OVERDUE");
-            public int MEP_CREATE_TASK_FAILED => CallStatic<int>("MEP_CREATE_TASK_FAILED");
-            public int MEP_QUERY_TASK_FAILED => CallStatic<int>("MEP_QUERY_TASK_FAILED");
+            public static int BILLING_OVERDUE => sJavaClass.GetStatic<int>("BILLING_OVERDUE");
+            public static int MEP_CREATE_TASK_FAILED => sJavaClass.GetStatic<int>("MEP_CREATE_TASK_FAILED");
+            public static int MEP_QUERY_TASK_FAILED => sJavaClass.GetStatic<int>("MEP_QUERY_TASK_FAILED");
 
         }
         /// <summary>
@@ -64,25 +66,28 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk
         /// </summary>
         public class FaceLevel : JavaObjectWrapper
         {
+            private const string CLASS_NAME = "com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$FaceLevel";
             public FaceLevel(AndroidJavaObject javaObject) : base(javaObject) { }
 
-            public FaceLevel() : base("com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$FaceLevel", AndroidContext.ActivityContext) { }
+            public FaceLevel() : base(CLASS_NAME, AndroidContext.ActivityContext) { }
+
+            private static AndroidJavaClass sJavaClass = new AndroidJavaClass(CLASS_NAME);
 
             /// <summary>
             /// Low face level.
             /// </summary>
             /// <returns>Face level = 2 </returns>
-            public int LOW => CallStatic<int>("LOW");
+            public static int LOW => sJavaClass.GetStatic<int>("LOW");
             /// <summary>
             /// Medium face level.
             /// </summary>
             /// <returns>Face level = 1 </returns>
-            public int MEDIUM => CallStatic<int>("MEDIUM");
+            public static int MEDIUM => sJavaClass.GetStatic<int>("MEDIUM");
             /// <summary>
             /// High face level.
             /// </summary>
             /// <returns>Face level = 0 </returns>
-            public int HIGH => CallStatic<int>("HIGH");
+            public static int HIGH => sJavaClass.GetStatic<int>("HIGH");
 
         }
         /// <summary>
@@ -90,41 +95,48 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk
         /// </summary>
         public class NeedRescan : JavaObjectWrapper
         {
+            private const string CLASS_NAME = "com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$NeedRescan";
             public NeedRescan(AndroidJavaObject javaObject) : base(javaObject) { }
 
-            public NeedRescan() : base("com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$NeedRescan", AndroidContext.ActivityContext) { }
+            public NeedRescan() : base(CLASS_NAME, AndroidContext.ActivityContext) { }
+
+            private static AndroidJavaClass sJavaClass = new AndroidJavaClass(CLASS_NAME);
+
 
             /// <summary>
             /// Enabled.
             /// </summary>
             /// <returns>true</returns>
-            public bool OPEN => Convert.ToBoolean(CallAsString("OPEN"));
+            public static bool OPEN => Convert.ToBoolean(sJavaClass.GetStatic<string>("OPEN"));        
             /// <summary>
             /// Disabled.
             /// </summary>
             /// <returns>false</returns>
-            public bool CLOSE => Convert.ToBoolean(CallAsString("CLOSE"));
-
+            public static bool CLOSE => Convert.ToBoolean(sJavaClass.GetStatic<string>("CLOSE"));
         }
         /// <summary>
         /// Texture map mode, which is specified in Modeling3dReconstructConstants.
         /// </summary>
         public class TextureMode : JavaObjectWrapper
         {
+            private const string CLASS_NAME = "com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$TextureMode";
+
             public TextureMode(AndroidJavaObject javaObject) : base(javaObject) { }
 
-            public TextureMode() : base("com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$TextureMode", AndroidContext.ActivityContext) { }
+            public TextureMode() : base(CLASS_NAME, AndroidContext.ActivityContext) { }
+
+            private static AndroidJavaClass sJavaClass = new AndroidJavaClass(CLASS_NAME);
 
             /// <summary>
             /// Texture mode: NORMAL.
             /// </summary>
             /// <returns> 0 </returns>
-            public int NORMAL => CallStatic<int>("NORMAL");
+            public static int NORMAL => sJavaClass.GetStatic<int>("NORMAL");
             /// <summary>
             /// Texture mode: PBR.
             /// </summary>
             /// <returns> 1 </returns>
-            public int PBR => CallStatic<int>("PBR");
+            public static int PBR =>    sJavaClass.GetStatic<int>("PBR");
 
         }
         /// <summary>
@@ -132,45 +144,52 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk
         /// </summary>
         public class ModelFormat : JavaObjectWrapper
         {
+            private const string CLASS_NAME = "com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$ModelFormat";
+
             public ModelFormat(AndroidJavaObject javaObject) : base(javaObject) { }
-            public ModelFormat() : base("com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$ModelFormat", AndroidContext.ActivityContext) { }
+            public ModelFormat() : base(CLASS_NAME, AndroidContext.ActivityContext) { }
+
+            private static AndroidJavaClass sJavaClass = new AndroidJavaClass(CLASS_NAME);
             /// <summary>
             /// Model format: OBJ.
             /// </summary>
             /// <returns> OBJ </returns>
-            public string OBJ => CallAsString("OBJ");
+            public static string OBJ => sJavaClass.GetStatic<string>("OBJ");
             /// <summary>
             /// Model format: GLTF.
             /// </summary>
             /// <returns> GLTF </returns>
-            public string GLTF => CallAsString("GLTF");
+            public static string GLTF => sJavaClass.GetStatic<string>("OBJ");
             /// <summary>
             /// Model format: FBX.
             /// </summary>
             /// <returns> FBX </returns>
-            public string FBX => CallAsString("FBX");
-        
+            public static string FBX => sJavaClass.GetStatic<string>("FBX");
+
         }
         /// <summary>
         /// Type of a 3D object reconstruction task, which is specified in Modeling3dReconstructConstants.
         /// </summary>
         public class TaskType : JavaObjectWrapper
         {
+            private const string CLASS_NAME = "com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$TaskType";
+
             public TaskType(AndroidJavaObject javaObject) : base(javaObject) { }
 
-            public TaskType() : base("com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$TaskType", AndroidContext.ActivityContext) { }
+            public TaskType() : base(CLASS_NAME, AndroidContext.ActivityContext) { }
+
+            private static AndroidJavaClass sJavaClass = new AndroidJavaClass(CLASS_NAME);
 
             /// <summary>
             /// Task type: 3D object reconstruction.
             /// </summary>
             /// <returns> 0 </returns>
-            public int OBJ_RECONSTRUCT => CallStatic<int>("OBJ_RECONSTRUCT");
+            public static int OBJ_RECONSTRUCT => sJavaClass.GetStatic<int>("OBJ_RECONSTRUCT");
             /// <summary>
             /// Task type: Auto rigging.
             /// </summary>
             /// <returns> 2 </returns>
-            public int AUTO_RIGGING =>  CallStatic<int>("AUTO_RIGGING");
-
+            public static int AUTO_RIGGING => sJavaClass.GetStatic<int>("AUTO_RIGGING");
 
         }
         /// <summary>
@@ -178,91 +197,101 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk
         /// </summary>
         public class RestrictStatus : JavaObjectWrapper
         {
+            private const string CLASS_NAME = "com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$RestrictStatus";
+
             public RestrictStatus(AndroidJavaObject javaObject) : base(javaObject) { }
 
-            public RestrictStatus() : base("com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$RestrictStatus", AndroidContext.ActivityContext) { }
+            public RestrictStatus() : base(CLASS_NAME, AndroidContext.ActivityContext) { }
+
+            private static AndroidJavaClass sJavaClass = new AndroidJavaClass(CLASS_NAME);
 
             /// <summary>
             /// Restrict status: Not restricted.
             /// </summary>
             /// <returns> 0 </returns>
-            public int UNRESTRICT => CallStatic<int>("UNRESTRICT");
+            public static int UNRESTRICT =>sJavaClass.GetStatic<int>("UNRESTRICT");
             /// <summary>
             /// Restrict status: Restricted.
             /// </summary>
             /// <returns> 1 </returns>
-            public int RESTRICT => CallStatic<int>("RESTRICT");
-
+            public static int RESTRICT =>sJavaClass.GetStatic<int>("RESTRICT");
         }
         /// <summary>
         /// Status of a 3D object reconstruction task, which is specified in Modeling3dReconstructConstants.
         /// </summary>
         public class ProgressStatus : JavaObjectWrapper
         {
+            private const string CLASS_NAME = "com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$ProgressStatus";
+
             public ProgressStatus(AndroidJavaObject javaObject) : base(javaObject) { }
 
-            public ProgressStatus() : base("com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$ProgressStatus", AndroidContext.ActivityContext) { }
+            public ProgressStatus() : base(CLASS_NAME, AndroidContext.ActivityContext) { }
+
+            private static AndroidJavaClass sJavaClass = new AndroidJavaClass(CLASS_NAME);
 
             /// <summary>
             /// Progress status: Task initialization is complete.
             /// </summary>
             /// <returns>Progress status = 0 </returns>
-            public int INITED => CallStatic<int>("INITED");
+            public static int INITED => sJavaClass.GetStatic<int>("INITED");
             /// <summary>
             /// Progress status: File upload is complete.
             /// </summary>
             /// <returns>Progress status = 1 </returns>
-            public int UPLOAD_COMPLETED => CallStatic<int>("UPLOAD_COMPLETED");
+            public static int UPLOAD_COMPLETED => sJavaClass.GetStatic<int>("UPLOAD_COMPLETED");
             /// <summary>
             /// Progress status: A 3D object reconstruction task starts.
             /// </summary>
             /// <returns>Progress status = 2 </returns>
-            public int RECONSTRUCT_START => CallStatic<int>("RECONSTRUCT_START");
+            public static int RECONSTRUCT_START => sJavaClass.GetStatic<int>("RECONSTRUCT_START");
             /// <summary>
             /// Progress status: A 3D object reconstruction task is complete.
             /// </summary>
             /// <returns>Progress status = 3 </returns>
-            public int RECONSTRUCT_COMPLETED => CallStatic<int>("RECONSTRUCT_COMPLETED");
+            public static int RECONSTRUCT_COMPLETED => sJavaClass.GetStatic<int>("RECONSTRUCT_COMPLETED");
             /// <summary>
             /// Progress status: A 3D object reconstruction task fails.
             /// </summary>
             /// <returns>Progress status = 4 </returns>
-            public int RECONSTRUCT_FAILED => CallStatic<int>("RECONSTRUCT_FAILED");
+            public static int RECONSTRUCT_FAILED => sJavaClass.GetStatic<int>("RECONSTRUCT_FAILED");
             /// <summary>
             /// Progress status: The 3D object reconstruction task is under risk control check.
             /// </summary>
             /// <returns>Progress status = 5 </returns>
-            public int RISK_CONTROL_AUDIT_IN_PROGRESS => CallStatic<int>("RISK_CONTROL_AUDIT_IN_PROGRESS");
+            public static int RISK_CONTROL_AUDIT_IN_PROGRESS => sJavaClass.GetStatic<int>("RISK_CONTROL_AUDIT_IN_PROGRESS");
             /// <summary>
             /// Progress status: The 3D object reconstruction task passes the risk control check.
             /// </summary>
             /// <returns>Progress status = 6 </returns>
-            public int RISK_CONTROL_PASSED => CallStatic<int>("RISK_CONTROL_PASSED");
+            public static int RISK_CONTROL_PASSED => sJavaClass.GetStatic<int>("RISK_CONTROL_PASSED");
             /// <summary>
             /// Progress status: The 3D object reconstruction task failed to pass the risk control check. Submit a ticket online, and Huawei technical support will handle it in time.
             /// </summary>
             /// <returns>Progress status = 7 </returns>
-            public int RISK_CONTROL_FAILED => CallStatic<int>("RISK_CONTROL_FAILED");
+            public static int RISK_CONTROL_FAILED => sJavaClass.GetStatic<int>("RISK_CONTROL_FAILED");
             /// <summary>
             /// Progress status: The task deleted.
             /// </summary>
             /// <returns>Progress status = 8 </returns>
-            public int TASK_DELETED => CallStatic<int>("TASK_DELETED");
+            public static int TASK_DELETED => sJavaClass.GetStatic<int>("TASK_DELETED");
         }
         /// <summary>
         /// Working mode for 3D object reconstruction, which is specified in Modeling3dReconstructConstants.
         /// </summary>
         public class ReconstructMode : JavaObjectWrapper
         {
+            private const string CLASS_NAME = "com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$ReconstructMode";
+
             public ReconstructMode(AndroidJavaObject javaObject) : base(javaObject) { }
 
-            public ReconstructMode() : base("com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$ReconstructMode", AndroidContext.ActivityContext) { }
+            public ReconstructMode() : base(CLASS_NAME, AndroidContext.ActivityContext) { }
+            private static AndroidJavaClass sJavaClass = new AndroidJavaClass(CLASS_NAME);
 
             /// <summary>
             /// Reconstruct mode: PICTURE mode
             /// </summary>
             /// <returns>Reconstruct mode = 0 </returns>
-            public int PICTURE => CallStatic<int>("PICTURE");
+            public static int PICTURE => sJavaClass.GetStatic<int>("PICTURE");
 
         }
     }

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Modeling3dReconstructConstants.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Modeling3dReconstructConstants.cs
@@ -1,0 +1,269 @@
+using System;
+using HuaweiMobileServices.Utils;
+using UnityEngine;
+namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk
+{
+    //wrapper for com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants
+    //https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructconstants-0000001153012999
+    public class Modeling3dReconstructConstants : JavaObjectWrapper
+    {
+        //private static AndroidJavaClass sJavaClass = new AndroidJavaClass("com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants");
+
+        public Modeling3dReconstructConstants(AndroidJavaObject javaObject) : base(javaObject)
+        {
+        }
+        public static explicit operator Modeling3dReconstructConstants(AndroidJavaObject javaObject) => javaObject == null ? null : new Modeling3dReconstructConstants(javaObject);
+
+        /// <summary>
+        /// Reason for a failed 3D object reconstruction task, which is specified in Modeling3dReconstructConstants.
+        /// </summary>
+        public class ReconstructFailCode : JavaObjectWrapper
+        {
+            //Not necessary to implement this because class name is the same as the java class name
+            //private static AndroidJavaClass sJavaClass = new AndroidJavaClass("com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants");
+            public ReconstructFailCode(AndroidJavaObject javaObject) : base(javaObject) { }
+
+            public ReconstructFailCode() : base("com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$ReconstructFailCode", AndroidContext.ActivityContext) { }
+
+            /// <summary>
+            /// Internal error.
+            /// <returns>Error code = 1 </returns>
+            /// </summary>
+            public int INNER_ERROR => CallStatic<int>("INNER_ERROR");
+            /// <summary>
+            /// Image file verification failed.
+            /// <returns>Error code = 2 </returns>
+            /// </summary>
+            public int FILE_CHECK_FAILED => CallStatic<int>("FILE_CHECK_FAILED");
+            /// <summary>
+            /// Invalid image.
+            /// </summary>
+            /// <returns>Error code = 3 </returns>
+            public int PICTURE_ILLEGAL => CallStatic<int>("PICTURE_ILLEGAL");
+            /// <summary>
+            /// The algorithm processing failed.
+            /// </summary>
+            /// <returns>Error code = 4 </returns>s
+            public int ALGORITHM_FAILED => CallStatic<int>("ALGORITHM_FAILED");
+            /// <summary>
+            /// The quota of API calls is used up.
+            /// </summary>
+            /// <returns>Error code = 5 </returns>
+            public int BILLING_QUOTA_EXHAUSTED => CallStatic<int>("BILLING_QUOTA_EXHAUSTED");
+            /// <summary>
+            /// The project is in arrears.
+            /// </summary>
+            /// <returns>Error code = 6 </returns>
+            public int BILLING_OVERDUE => CallStatic<int>("BILLING_OVERDUE");
+            public int MEP_CREATE_TASK_FAILED => CallStatic<int>("MEP_CREATE_TASK_FAILED");
+            public int MEP_QUERY_TASK_FAILED => CallStatic<int>("MEP_QUERY_TASK_FAILED");
+
+        }
+        /// <summary>
+        /// Mesh count level for a 3D object reconstruction task, which is specified in Modeling3dReconstructConstants.
+        /// </summary>
+        public class FaceLevel : JavaObjectWrapper
+        {
+            public FaceLevel(AndroidJavaObject javaObject) : base(javaObject) { }
+
+            public FaceLevel() : base("com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$FaceLevel", AndroidContext.ActivityContext) { }
+
+            /// <summary>
+            /// Low face level.
+            /// </summary>
+            /// <returns>Face level = 2 </returns>
+            public int LOW => CallStatic<int>("LOW");
+            /// <summary>
+            /// Medium face level.
+            /// </summary>
+            /// <returns>Face level = 1 </returns>
+            public int MEDIUM => CallStatic<int>("MEDIUM");
+            /// <summary>
+            /// High face level.
+            /// </summary>
+            /// <returns>Face level = 0 </returns>
+            public int HIGH => CallStatic<int>("HIGH");
+
+        }
+        /// <summary>
+        /// Extra scanning status of a 3D object reconstruction task, which is specified in Modeling3dReconstructConstants.
+        /// </summary>
+        public class NeedRescan : JavaObjectWrapper
+        {
+            public NeedRescan(AndroidJavaObject javaObject) : base(javaObject) { }
+
+            public NeedRescan() : base("com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$NeedRescan", AndroidContext.ActivityContext) { }
+
+            /// <summary>
+            /// Enabled.
+            /// </summary>
+            /// <returns>true</returns>
+            public bool OPEN => Convert.ToBoolean(CallAsString("OPEN"));
+            /// <summary>
+            /// Disabled.
+            /// </summary>
+            /// <returns>false</returns>
+            public bool CLOSE => Convert.ToBoolean(CallAsString("CLOSE"));
+
+        }
+        /// <summary>
+        /// Texture map mode, which is specified in Modeling3dReconstructConstants.
+        /// </summary>
+        public class TextureMode : JavaObjectWrapper
+        {
+            public TextureMode(AndroidJavaObject javaObject) : base(javaObject) { }
+
+            public TextureMode() : base("com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$TextureMode", AndroidContext.ActivityContext) { }
+
+            /// <summary>
+            /// Texture mode: NORMAL.
+            /// </summary>
+            /// <returns> 0 </returns>
+            public int NORMAL => CallStatic<int>("NORMAL");
+            /// <summary>
+            /// Texture mode: PBR.
+            /// </summary>
+            /// <returns> 1 </returns>
+            public int PBR => CallStatic<int>("PBR");
+
+        }
+        /// <summary>
+        /// 3D model format, which is specified in Modeling3dReconstructConstants.
+        /// </summary>
+        public class ModelFormat : JavaObjectWrapper
+        {
+            public ModelFormat(AndroidJavaObject javaObject) : base(javaObject) { }
+            public ModelFormat() : base("com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$ModelFormat", AndroidContext.ActivityContext) { }
+            /// <summary>
+            /// Model format: OBJ.
+            /// </summary>
+            /// <returns> OBJ </returns>
+            public string OBJ => CallAsString("OBJ");
+            /// <summary>
+            /// Model format: GLTF.
+            /// </summary>
+            /// <returns> GLTF </returns>
+            public string GLTF => CallAsString("GLTF");
+            /// <summary>
+            /// Model format: FBX.
+            /// </summary>
+            /// <returns> FBX </returns>
+            public string FBX => CallAsString("FBX");
+        
+        }
+        /// <summary>
+        /// Type of a 3D object reconstruction task, which is specified in Modeling3dReconstructConstants.
+        /// </summary>
+        public class TaskType : JavaObjectWrapper
+        {
+            public TaskType(AndroidJavaObject javaObject) : base(javaObject) { }
+
+            public TaskType() : base("com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$TaskType", AndroidContext.ActivityContext) { }
+
+            /// <summary>
+            /// Task type: 3D object reconstruction.
+            /// </summary>
+            /// <returns> 0 </returns>
+            public int OBJ_RECONSTRUCT => CallStatic<int>("OBJ_RECONSTRUCT");
+            /// <summary>
+            /// Task type: Auto rigging.
+            /// </summary>
+            /// <returns> 2 </returns>
+            public int AUTO_RIGGING =>  CallStatic<int>("AUTO_RIGGING");
+
+
+        }
+        /// <summary>
+        /// Restriction status of a 3D object reconstruction task, which is specified in Modeling3dReconstructConstants.
+        /// </summary>
+        public class RestrictStatus : JavaObjectWrapper
+        {
+            public RestrictStatus(AndroidJavaObject javaObject) : base(javaObject) { }
+
+            public RestrictStatus() : base("com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$RestrictStatus", AndroidContext.ActivityContext) { }
+
+            /// <summary>
+            /// Restrict status: Not restricted.
+            /// </summary>
+            /// <returns> 0 </returns>
+            public int UNRESTRICT => CallStatic<int>("UNRESTRICT");
+            /// <summary>
+            /// Restrict status: Restricted.
+            /// </summary>
+            /// <returns> 1 </returns>
+            public int RESTRICT => CallStatic<int>("RESTRICT");
+
+        }
+        /// <summary>
+        /// Status of a 3D object reconstruction task, which is specified in Modeling3dReconstructConstants.
+        /// </summary>
+        public class ProgressStatus : JavaObjectWrapper
+        {
+            public ProgressStatus(AndroidJavaObject javaObject) : base(javaObject) { }
+
+            public ProgressStatus() : base("com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$ProgressStatus", AndroidContext.ActivityContext) { }
+
+            /// <summary>
+            /// Progress status: Task initialization is complete.
+            /// </summary>
+            /// <returns>Progress status = 0 </returns>
+            public int INITED => CallStatic<int>("INITED");
+            /// <summary>
+            /// Progress status: File upload is complete.
+            /// </summary>
+            /// <returns>Progress status = 1 </returns>
+            public int UPLOAD_COMPLETED => CallStatic<int>("UPLOAD_COMPLETED");
+            /// <summary>
+            /// Progress status: A 3D object reconstruction task starts.
+            /// </summary>
+            /// <returns>Progress status = 2 </returns>
+            public int RECONSTRUCT_START => CallStatic<int>("RECONSTRUCT_START");
+            /// <summary>
+            /// Progress status: A 3D object reconstruction task is complete.
+            /// </summary>
+            /// <returns>Progress status = 3 </returns>
+            public int RECONSTRUCT_COMPLETED => CallStatic<int>("RECONSTRUCT_COMPLETED");
+            /// <summary>
+            /// Progress status: A 3D object reconstruction task fails.
+            /// </summary>
+            /// <returns>Progress status = 4 </returns>
+            public int RECONSTRUCT_FAILED => CallStatic<int>("RECONSTRUCT_FAILED");
+            /// <summary>
+            /// Progress status: The 3D object reconstruction task is under risk control check.
+            /// </summary>
+            /// <returns>Progress status = 5 </returns>
+            public int RISK_CONTROL_AUDIT_IN_PROGRESS => CallStatic<int>("RISK_CONTROL_AUDIT_IN_PROGRESS");
+            /// <summary>
+            /// Progress status: The 3D object reconstruction task passes the risk control check.
+            /// </summary>
+            /// <returns>Progress status = 6 </returns>
+            public int RISK_CONTROL_PASSED => CallStatic<int>("RISK_CONTROL_PASSED");
+            /// <summary>
+            /// Progress status: The 3D object reconstruction task failed to pass the risk control check. Submit a ticket online, and Huawei technical support will handle it in time.
+            /// </summary>
+            /// <returns>Progress status = 7 </returns>
+            public int RISK_CONTROL_FAILED => CallStatic<int>("RISK_CONTROL_FAILED");
+            /// <summary>
+            /// Progress status: The task deleted.
+            /// </summary>
+            /// <returns>Progress status = 8 </returns>
+            public int TASK_DELETED => CallStatic<int>("TASK_DELETED");
+        }
+        /// <summary>
+        /// Working mode for 3D object reconstruction, which is specified in Modeling3dReconstructConstants.
+        /// </summary>
+        public class ReconstructMode : JavaObjectWrapper
+        {
+            public ReconstructMode(AndroidJavaObject javaObject) : base(javaObject) { }
+
+            public ReconstructMode() : base("com.huawei.hms.objreconstructsdk.Modeling3dReconstructConstants$ReconstructMode", AndroidContext.ActivityContext) { }
+
+            /// <summary>
+            /// Reconstruct mode: PICTURE mode
+            /// </summary>
+            /// <returns>Reconstruct mode = 0 </returns>
+            public int PICTURE => CallStatic<int>("PICTURE");
+
+        }
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Modeling3dReconstructErrors.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Modeling3dReconstructErrors.cs
@@ -12,7 +12,7 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk
         {
         }
         //Not necessary to implement this because class name is the same as the java class name
-        //private static AndroidJavaClass sJavaClass = new AndroidJavaClass("com.huawei.hms.objreconstructsdk.Modeling3dReconstructErrors");
+        private static AndroidJavaClass sJavaClass = new AndroidJavaClass("com.huawei.hms.objreconstructsdk.Modeling3dReconstructErrors");
 
         public static explicit operator Modeling3dReconstructErrors(AndroidJavaObject javaObject) => javaObject == null ? null : new Modeling3dReconstructErrors(javaObject);
 
@@ -20,202 +20,202 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk
         /// Unsupported image format.
         /// </summary>
         /// <returns>Error code = 1100 </returns>
-        public int ERR_IMAGE_FILE_NOTSUPPORTED => CallStatic<int>("ERR_IMAGE_FILE_NOTSUPPORTED");
+        public static int ERR_IMAGE_FILE_NOTSUPPORTED => sJavaClass.GetStatic<int>("ERR_IMAGE_FILE_NOTSUPPORTED");
         /// <summary>
         /// The number of image files is not supported.
         /// </summary>
         /// <returns>Error code = 1102 </returns>
-        public int ERR_FILE_NUMBER_NOT_SUPPORT => CallStatic<int>("ERR_FILE_NUMBER_NOT_SUPPORT");
+        public static int ERR_FILE_NUMBER_NOT_SUPPORT => sJavaClass.GetStatic<int>("ERR_FILE_NUMBER_NOT_SUPPORT");
         /// <summary>
         /// The image file size is too large.
         /// </summary>
         /// <returns>Error code = 1101 </returns>
-        public int ERR_FILE_SIZE_OVERFLOW => CallStatic<int>("ERR_FILE_SIZE_OVERFLOW");
+        public static int ERR_FILE_SIZE_OVERFLOW => sJavaClass.GetStatic<int>("ERR_FILE_SIZE_OVERFLOW");
         /// <summary>
         /// The image file does not exist.
         /// </summary>
         /// <returns>Error code = 1103 </returns>
-        public int ERR_FILE_NOT_FOUND => CallStatic<int>("ERR_FILE_NOT_FOUND");
+        public static int ERR_FILE_NOT_FOUND => sJavaClass.GetStatic<int>("ERR_FILE_NOT_FOUND");
         /// <summary>
         /// The number of API calls exceeds the daily maximum.
         /// </summary>
         /// <returns>Error code = 1118 </returns>
-        public int ERR_RET_OVER_DAY_MAX_LIMIT => CallStatic<int>("ERR_RET_OVER_DAY_MAX_LIMIT");
+        public static int ERR_RET_OVER_DAY_MAX_LIMIT => sJavaClass.GetStatic<int>("ERR_RET_OVER_DAY_MAX_LIMIT");
         /// <summary>
         /// The number of API calls exceeds the monthly maximum.
         /// </summary>
         /// <returns>Error code = 1137 </returns>
-        public int ERR_RET_OVER_MONTH_MAX_LIMIT => CallStatic<int>("ERR_RET_OVER_MONTH_MAX_LIMIT");
+        public static int ERR_RET_OVER_MONTH_MAX_LIMIT => sJavaClass.GetStatic<int>("ERR_RET_OVER_MONTH_MAX_LIMIT");
         /// <summary>
         /// Invalid parameter.
         /// </summary>
         /// <returns>Error code = 1104 </returns>
-        public int ERR_ILLEGAL_PARAMETER => CallStatic<int>("ERR_ILLEGAL_PARAMETER");
+        public static int ERR_ILLEGAL_PARAMETER => sJavaClass.GetStatic<int>("ERR_ILLEGAL_PARAMETER");
         /// <summary>
         /// The reconstruction engine is busy.
         /// </summary>
         /// <returns>Error code = 1105 </returns>
-        public int ERR_ENGINE_BUSY => CallStatic<int>("ERR_ENGINE_BUSY");
+        public static int ERR_ENGINE_BUSY => sJavaClass.GetStatic<int>("ERR_ENGINE_BUSY");
         /// <summary>
         /// Image upload failed.
         /// </summary>
         /// <returns>Error code = 1106 </returns>
-        public int ERR_UPLOAD_FILE_FAILED => CallStatic<int>("ERR_UPLOAD_FILE_FAILED");
+        public static int ERR_UPLOAD_FILE_FAILED => sJavaClass.GetStatic<int>("ERR_UPLOAD_FILE_FAILED");
         /// <summary>
         /// The task is being executed and cannot be submitted again.
         /// </summary>
         /// <returns>Error code = 1107 </returns>
-        public int ERR_TASK_ALREADY_INPROGRESS => CallStatic<int>("ERR_TASK_ALREADY_INPROGRESS");
+        public static int ERR_TASK_ALREADY_INPROGRESS => sJavaClass.GetStatic<int>("ERR_TASK_ALREADY_INPROGRESS");
         /// <summary>
         /// Query failed.
         /// </summary>
         /// <returns>Error code = 1108 </returns>
-        public int ERR_QUERY_FAILED => CallStatic<int>("ERR_QUERY_FAILED");
+        public static int ERR_QUERY_FAILED => sJavaClass.GetStatic<int>("ERR_QUERY_FAILED");
         /// <summary>
         /// Download failed.
         /// </summary>
         /// <returns>Error code = 1109 </returns>
-        public int ERR_DOWNLOAD_FAILED => CallStatic<int>("ERR_DOWNLOAD_FAILED");
+        public static int ERR_DOWNLOAD_FAILED => sJavaClass.GetStatic<int>("ERR_DOWNLOAD_FAILED");
         /// <summary>
         /// Network connection error.
         /// </summary>
         /// <returns>Error code = 1110 </returns>
-        public int ERR_NETCONNECT_FAILED => CallStatic<int>("ERR_NETCONNECT_FAILED");
+        public static int ERR_NETCONNECT_FAILED => sJavaClass.GetStatic<int>("ERR_NETCONNECT_FAILED");
         /// <summary>
         /// Authentication failed.
         /// </summary>
         /// <returns>Error code = 1111 </returns>
-        public int ERR_AUTHORIZE_FAILED => CallStatic<int>("ERR_AUTHORIZE_FAILED");
+        public static int ERR_AUTHORIZE_FAILED => sJavaClass.GetStatic<int>("ERR_AUTHORIZE_FAILED");
         /// <summary>
         /// Server error.
         /// </summary>
         /// <returns>Error code = 1112 </returns>
-        public int ERR_SERVICE_EXCEPTION => CallStatic<int>("ERR_SERVICE_EXCEPTION");
+        public static int ERR_SERVICE_EXCEPTION => sJavaClass.GetStatic<int>("ERR_SERVICE_EXCEPTION");
         /// <summary>
         /// Internal error.
         /// </summary>
         /// <returns>Error code = 1113 </returns>
-        public int ERR_INTERNAL => CallStatic<int>("ERR_INTERNAL");
+        public static int ERR_INTERNAL => sJavaClass.GetStatic<int>("ERR_INTERNAL");
         /// <summary>
         /// The 3D object reconstruction task does not exist.
         /// </summary>
         /// <returns>Error code = 1114 </returns>
-        public int ERR_TASKID_NOT_EXISTED => CallStatic<int>("ERR_TASKID_NOT_EXISTED");
+        public static int ERR_TASKID_NOT_EXISTED => sJavaClass.GetStatic<int>("ERR_TASKID_NOT_EXISTED");
         /// <summary>
         /// Invalid task status.
         /// </summary>
         /// <returns>Error code = 1115 </returns>
-        public int ERR_ILLEGAL_TASK_STATUS => CallStatic<int>("ERR_ILLEGAL_TASK_STATUS");
+        public static int ERR_ILLEGAL_TASK_STATUS => sJavaClass.GetStatic<int>("ERR_ILLEGAL_TASK_STATUS");
         /// <summary>
         /// The access token is invalid or has expired.
         /// </summary>
         /// <returns>Error code = 1116 </returns>
-        public int ERR_ILLEGAL_TOKEN => CallStatic<int>("ERR_ILLEGAL_TOKEN");
+        public static int ERR_ILLEGAL_TOKEN => sJavaClass.GetStatic<int>("ERR_ILLEGAL_TOKEN");
         /// <summary>
         /// The task result has expired.
         /// </summary>
         /// <returns>Error code = 1117 </returns>
-        public int ERR_TASK_EXPIRED => CallStatic<int>("ERR_TASK_EXPIRED");
+        public static int ERR_TASK_EXPIRED => sJavaClass.GetStatic<int>("ERR_TASK_EXPIRED");
         /// <summary>
         /// Failed to cancel the upload.
         /// </summary>
         /// <returns>Error code = 1119 </returns>
-        public int ERR_UPLOAD_CANCEL_FAILED => CallStatic<int>("ERR_UPLOAD_CANCEL_FAILED");
+        public static int ERR_UPLOAD_CANCEL_FAILED => sJavaClass.GetStatic<int>("ERR_UPLOAD_CANCEL_FAILED");
         /// <summary>
         /// Failed to cancel the download
         /// </summary>
         /// <returns>Error code = 1120 </returns>
-        public int ERR_DOWNLOAD_CANCEL_FAILED => CallStatic<int>("ERR_DOWNLOAD_CANCEL_FAILED");
+        public static int ERR_DOWNLOAD_CANCEL_FAILED => sJavaClass.GetStatic<int>("ERR_DOWNLOAD_CANCEL_FAILED");
         /// <summary>
         /// Task initialization failed.
         /// </summary>
         /// <returns>Error code = 1121 </returns>
-        public int ERR_INIT_TASK_FAILED => CallStatic<int>("ERR_INIT_TASK_FAILED");
+        public static int ERR_INIT_TASK_FAILED => sJavaClass.GetStatic<int>("ERR_INIT_TASK_FAILED");
         /// <summary>
         /// Unknown error.
         /// </summary>
         /// <returns>Error code = 1122 </returns>
-        public int ERR_UNKNOWN => CallStatic<int>("ERR_UNKNOWN");
+        public static int ERR_UNKNOWN => sJavaClass.GetStatic<int>("ERR_UNKNOWN");
         /// <summary>
         /// Unsupported input image resolution.
         /// </summary>
         /// <returns>Error code = 1123 </returns>
-        public int ERR_IMAGE_RESOLUTION_NOTSUPPORTED => CallStatic<int>("ERR_IMAGE_RESOLUTION_NOTSUPPORTED");
+        public static int ERR_IMAGE_RESOLUTION_NOTSUPPORTED => sJavaClass.GetStatic<int>("ERR_IMAGE_RESOLUTION_NOTSUPPORTED");
         /// <summary>
         /// Inconsistent input image resolutions.
         /// </summary>
         /// <returns>Error code = 1124 </returns>
-        public int ERR_IMAGE_RESOLUTION_INCONSISTENT => CallStatic<int>("ERR_IMAGE_RESOLUTION_INCONSISTENT");
+        public static int ERR_IMAGE_RESOLUTION_INCONSISTENT => sJavaClass.GetStatic<int>("ERR_IMAGE_RESOLUTION_INCONSISTENT");
         /// <summary>
         /// Unsupported input image format.
         /// </summary>
         /// <returns>Error code = 1125 </returns>
-        public int ERR_IMAGE_TYPE_INCONSISTENT => CallStatic<int>("ERR_IMAGE_TYPE_INCONSISTENT");
+        public static int ERR_IMAGE_TYPE_INCONSISTENT => sJavaClass.GetStatic<int>("ERR_IMAGE_TYPE_INCONSISTENT");
         /// <summary>
         /// Failed to preview the model.
         /// </summary>
         /// <returns>Error code = 1126 </returns>
-        public int ERR_MODEL_PREVIEW_FAILED => CallStatic<int>("ERR_MODEL_PREVIEW_FAILED");
+        public static int ERR_MODEL_PREVIEW_FAILED => sJavaClass.GetStatic<int>("ERR_MODEL_PREVIEW_FAILED");
         /// <summary>
         /// Failed to delete the uploaded files from the cloud.
         /// </summary>
         /// <returns>Error code = 1127 </returns>
-        public int ERR_DELETE_REMOTE_FILE_FAILED => CallStatic<int>("ERR_DELETE_REMOTE_FILE_FAILED");
+        public static int ERR_DELETE_REMOTE_FILE_FAILED => sJavaClass.GetStatic<int>("ERR_DELETE_REMOTE_FILE_FAILED");
         /// <summary>
         /// The task is restricted.
         /// </summary>
         /// <returns>Error code = 1128 </returns>
-        public int ERR_TASK_RESTRICTED => CallStatic<int>("ERR_TASK_RESTRICTED");
+        public static int ERR_TASK_RESTRICTED => sJavaClass.GetStatic<int>("ERR_TASK_RESTRICTED");
         /// <summary>
         /// The data processing location is not set.
         /// </summary>
         /// <returns>Error code = 1129 </returns>
-        public int ERR_DATA_PROCESSING_LOCATION_NOT_SET => CallStatic<int>("ERR_DATA_PROCESSING_LOCATION_NOT_SET");
+        public static int ERR_DATA_PROCESSING_LOCATION_NOT_SET => sJavaClass.GetStatic<int>("ERR_DATA_PROCESSING_LOCATION_NOT_SET");
         /// <summary>
         /// The glTF format is not supported under the PBR mode.
         /// </summary>
         /// <returns>Error code = 1130 </returns>
-        public int ERR_GLTF_NOT_SUPPORT_PBR_TEXTURE_MODE => CallStatic<int>("ERR_GLTF_NOT_SUPPORT_PBR_TEXTURE_MODE");
+        public static int ERR_GLTF_NOT_SUPPORT_PBR_TEXTURE_MODE => sJavaClass.GetStatic<int>("ERR_GLTF_NOT_SUPPORT_PBR_TEXTURE_MODE");
         /// <summary>
         /// Invalid parameter.
         /// </summary>
         /// <returns>Error code = 1131 </returns>
-        public int ERR_PBR_MODE_NOT_EXIST => CallStatic<int>("ERR_PBR_MODE_NOT_EXIST");
+        public static int ERR_PBR_MODE_NOT_EXIST => sJavaClass.GetStatic<int>("ERR_PBR_MODE_NOT_EXIST");
         /// <summary>
         /// The free quota for 3D Modeling Kit has been used up.
         /// </summary>
         /// <returns>Error code = 1132 </returns>
-        public int ERR_RET_BILLING_QUOTA_EXHAUSTED => CallStatic<int>("ERR_RET_BILLING_QUOTA_EXHAUSTED");
+        public static int ERR_RET_BILLING_QUOTA_EXHAUSTED => sJavaClass.GetStatic<int>("ERR_RET_BILLING_QUOTA_EXHAUSTED");
         /// <summary>
         /// The account balance is insufficient to use 3D Modeling Kit.
         /// </summary>
         /// <returns>Error code = 1133 </returns>
-        public int ERR_RET_BILLING_OVERDUE => CallStatic<int>("ERR_RET_BILLING_OVERDUE");
+        public static int ERR_RET_BILLING_OVERDUE => sJavaClass.GetStatic<int>("ERR_RET_BILLING_OVERDUE");
         /// <summary>
         /// The free quota for 3D Modeling Kit has been used up.
         /// </summary>
         /// <returns>Error code = 1134 </returns>
-        public int ERR_RET_ORDER_NOT_EXIST => CallStatic<int>("ERR_RET_ORDER_NOT_EXIST");
+        public static int ERR_RET_ORDER_NOT_EXIST => sJavaClass.GetStatic<int>("ERR_RET_ORDER_NOT_EXIST");
         /// <summary>
         /// Preview is not supported for auto rigging.
         /// </summary>
         /// <returns>Error code = 1135 </returns>
-        public int ERR_AUTO_RIGGING_NOT_SUPPORT_PREVIEW => CallStatic<int>("ERR_AUTO_RIGGING_NOT_SUPPORT_PREVIEW");
+        public static int ERR_AUTO_RIGGING_NOT_SUPPORT_PREVIEW => sJavaClass.GetStatic<int>("ERR_AUTO_RIGGING_NOT_SUPPORT_PREVIEW");
         /// <summary>
         /// The number of extra scanning tasks exceeds the maximum.
         /// </summary>
         /// <returns>Error code = 1136 </returns>
-        public int ERR_RET_OVER_RESCAN_LIMIT => CallStatic<int>("ERR_RET_OVER_RESCAN_LIMIT");
+        public static int ERR_RET_OVER_RESCAN_LIMIT => sJavaClass.GetStatic<int>("ERR_RET_OVER_RESCAN_LIMIT");
         /// <summary>
         /// Extra scanning is unsupported by auto rigging.
         /// </summary>
         /// <returns>Error code = 1138 </returns>
-        public int ERR_RET_RIGGING_NOT_SUPPORT_RESCAN => CallStatic<int>("ERR_RET_RIGGING_NOT_SUPPORT_RESCAN");
+        public static int ERR_RET_RIGGING_NOT_SUPPORT_RESCAN => sJavaClass.GetStatic<int>("ERR_RET_RIGGING_NOT_SUPPORT_RESCAN");
         /// <summary>
         /// The mesh count level of an extra scanning task is inconsistent with that of the original task.
         /// </summary>
         /// <returns>Error code = 1139 </returns>
-        public int ERR_RET_PARAM_FACELEVEL_NOT_CONSISTENT_WITH_RESCAN => CallStatic<int>("ERR_RET_PARAM_FACELEVEL_NOT_CONSISTENT_WITH_RESCAN");
+        public static int ERR_RET_PARAM_FACELEVEL_NOT_CONSISTENT_WITH_RESCAN => sJavaClass.GetStatic<int>("ERR_RET_PARAM_FACELEVEL_NOT_CONSISTENT_WITH_RESCAN");
 
 
     }

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Modeling3dReconstructErrors.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/Modeling3dReconstructErrors.cs
@@ -1,0 +1,222 @@
+using HuaweiMobileServices.Utils;
+using UnityEngine;
+namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk
+{
+    /// <summary>
+    /// Wrapper for com.huawei.hms.objreconstructsdk.Modeling3dReconstructErrors
+    /// <see cref="Modeling3dReconstructErrors" link="https://developer.huawei.com/consumer/en/doc/development/graphics-References/modeling3dreconstructerrors-0000001153093111"/>
+    /// </summary>
+    public class Modeling3dReconstructErrors : JavaObjectWrapper
+    {
+        public Modeling3dReconstructErrors(AndroidJavaObject javaObject) : base(javaObject)
+        {
+        }
+        //Not necessary to implement this because class name is the same as the java class name
+        //private static AndroidJavaClass sJavaClass = new AndroidJavaClass("com.huawei.hms.objreconstructsdk.Modeling3dReconstructErrors");
+
+        public static explicit operator Modeling3dReconstructErrors(AndroidJavaObject javaObject) => javaObject == null ? null : new Modeling3dReconstructErrors(javaObject);
+
+        /// <summary>
+        /// Unsupported image format.
+        /// </summary>
+        /// <returns>Error code = 1100 </returns>
+        public int ERR_IMAGE_FILE_NOTSUPPORTED => CallStatic<int>("ERR_IMAGE_FILE_NOTSUPPORTED");
+        /// <summary>
+        /// The number of image files is not supported.
+        /// </summary>
+        /// <returns>Error code = 1102 </returns>
+        public int ERR_FILE_NUMBER_NOT_SUPPORT => CallStatic<int>("ERR_FILE_NUMBER_NOT_SUPPORT");
+        /// <summary>
+        /// The image file size is too large.
+        /// </summary>
+        /// <returns>Error code = 1101 </returns>
+        public int ERR_FILE_SIZE_OVERFLOW => CallStatic<int>("ERR_FILE_SIZE_OVERFLOW");
+        /// <summary>
+        /// The image file does not exist.
+        /// </summary>
+        /// <returns>Error code = 1103 </returns>
+        public int ERR_FILE_NOT_FOUND => CallStatic<int>("ERR_FILE_NOT_FOUND");
+        /// <summary>
+        /// The number of API calls exceeds the daily maximum.
+        /// </summary>
+        /// <returns>Error code = 1118 </returns>
+        public int ERR_RET_OVER_DAY_MAX_LIMIT => CallStatic<int>("ERR_RET_OVER_DAY_MAX_LIMIT");
+        /// <summary>
+        /// The number of API calls exceeds the monthly maximum.
+        /// </summary>
+        /// <returns>Error code = 1137 </returns>
+        public int ERR_RET_OVER_MONTH_MAX_LIMIT => CallStatic<int>("ERR_RET_OVER_MONTH_MAX_LIMIT");
+        /// <summary>
+        /// Invalid parameter.
+        /// </summary>
+        /// <returns>Error code = 1104 </returns>
+        public int ERR_ILLEGAL_PARAMETER => CallStatic<int>("ERR_ILLEGAL_PARAMETER");
+        /// <summary>
+        /// The reconstruction engine is busy.
+        /// </summary>
+        /// <returns>Error code = 1105 </returns>
+        public int ERR_ENGINE_BUSY => CallStatic<int>("ERR_ENGINE_BUSY");
+        /// <summary>
+        /// Image upload failed.
+        /// </summary>
+        /// <returns>Error code = 1106 </returns>
+        public int ERR_UPLOAD_FILE_FAILED => CallStatic<int>("ERR_UPLOAD_FILE_FAILED");
+        /// <summary>
+        /// The task is being executed and cannot be submitted again.
+        /// </summary>
+        /// <returns>Error code = 1107 </returns>
+        public int ERR_TASK_ALREADY_INPROGRESS => CallStatic<int>("ERR_TASK_ALREADY_INPROGRESS");
+        /// <summary>
+        /// Query failed.
+        /// </summary>
+        /// <returns>Error code = 1108 </returns>
+        public int ERR_QUERY_FAILED => CallStatic<int>("ERR_QUERY_FAILED");
+        /// <summary>
+        /// Download failed.
+        /// </summary>
+        /// <returns>Error code = 1109 </returns>
+        public int ERR_DOWNLOAD_FAILED => CallStatic<int>("ERR_DOWNLOAD_FAILED");
+        /// <summary>
+        /// Network connection error.
+        /// </summary>
+        /// <returns>Error code = 1110 </returns>
+        public int ERR_NETCONNECT_FAILED => CallStatic<int>("ERR_NETCONNECT_FAILED");
+        /// <summary>
+        /// Authentication failed.
+        /// </summary>
+        /// <returns>Error code = 1111 </returns>
+        public int ERR_AUTHORIZE_FAILED => CallStatic<int>("ERR_AUTHORIZE_FAILED");
+        /// <summary>
+        /// Server error.
+        /// </summary>
+        /// <returns>Error code = 1112 </returns>
+        public int ERR_SERVICE_EXCEPTION => CallStatic<int>("ERR_SERVICE_EXCEPTION");
+        /// <summary>
+        /// Internal error.
+        /// </summary>
+        /// <returns>Error code = 1113 </returns>
+        public int ERR_INTERNAL => CallStatic<int>("ERR_INTERNAL");
+        /// <summary>
+        /// The 3D object reconstruction task does not exist.
+        /// </summary>
+        /// <returns>Error code = 1114 </returns>
+        public int ERR_TASKID_NOT_EXISTED => CallStatic<int>("ERR_TASKID_NOT_EXISTED");
+        /// <summary>
+        /// Invalid task status.
+        /// </summary>
+        /// <returns>Error code = 1115 </returns>
+        public int ERR_ILLEGAL_TASK_STATUS => CallStatic<int>("ERR_ILLEGAL_TASK_STATUS");
+        /// <summary>
+        /// The access token is invalid or has expired.
+        /// </summary>
+        /// <returns>Error code = 1116 </returns>
+        public int ERR_ILLEGAL_TOKEN => CallStatic<int>("ERR_ILLEGAL_TOKEN");
+        /// <summary>
+        /// The task result has expired.
+        /// </summary>
+        /// <returns>Error code = 1117 </returns>
+        public int ERR_TASK_EXPIRED => CallStatic<int>("ERR_TASK_EXPIRED");
+        /// <summary>
+        /// Failed to cancel the upload.
+        /// </summary>
+        /// <returns>Error code = 1119 </returns>
+        public int ERR_UPLOAD_CANCEL_FAILED => CallStatic<int>("ERR_UPLOAD_CANCEL_FAILED");
+        /// <summary>
+        /// Failed to cancel the download
+        /// </summary>
+        /// <returns>Error code = 1120 </returns>
+        public int ERR_DOWNLOAD_CANCEL_FAILED => CallStatic<int>("ERR_DOWNLOAD_CANCEL_FAILED");
+        /// <summary>
+        /// Task initialization failed.
+        /// </summary>
+        /// <returns>Error code = 1121 </returns>
+        public int ERR_INIT_TASK_FAILED => CallStatic<int>("ERR_INIT_TASK_FAILED");
+        /// <summary>
+        /// Unknown error.
+        /// </summary>
+        /// <returns>Error code = 1122 </returns>
+        public int ERR_UNKNOWN => CallStatic<int>("ERR_UNKNOWN");
+        /// <summary>
+        /// Unsupported input image resolution.
+        /// </summary>
+        /// <returns>Error code = 1123 </returns>
+        public int ERR_IMAGE_RESOLUTION_NOTSUPPORTED => CallStatic<int>("ERR_IMAGE_RESOLUTION_NOTSUPPORTED");
+        /// <summary>
+        /// Inconsistent input image resolutions.
+        /// </summary>
+        /// <returns>Error code = 1124 </returns>
+        public int ERR_IMAGE_RESOLUTION_INCONSISTENT => CallStatic<int>("ERR_IMAGE_RESOLUTION_INCONSISTENT");
+        /// <summary>
+        /// Unsupported input image format.
+        /// </summary>
+        /// <returns>Error code = 1125 </returns>
+        public int ERR_IMAGE_TYPE_INCONSISTENT => CallStatic<int>("ERR_IMAGE_TYPE_INCONSISTENT");
+        /// <summary>
+        /// Failed to preview the model.
+        /// </summary>
+        /// <returns>Error code = 1126 </returns>
+        public int ERR_MODEL_PREVIEW_FAILED => CallStatic<int>("ERR_MODEL_PREVIEW_FAILED");
+        /// <summary>
+        /// Failed to delete the uploaded files from the cloud.
+        /// </summary>
+        /// <returns>Error code = 1127 </returns>
+        public int ERR_DELETE_REMOTE_FILE_FAILED => CallStatic<int>("ERR_DELETE_REMOTE_FILE_FAILED");
+        /// <summary>
+        /// The task is restricted.
+        /// </summary>
+        /// <returns>Error code = 1128 </returns>
+        public int ERR_TASK_RESTRICTED => CallStatic<int>("ERR_TASK_RESTRICTED");
+        /// <summary>
+        /// The data processing location is not set.
+        /// </summary>
+        /// <returns>Error code = 1129 </returns>
+        public int ERR_DATA_PROCESSING_LOCATION_NOT_SET => CallStatic<int>("ERR_DATA_PROCESSING_LOCATION_NOT_SET");
+        /// <summary>
+        /// The glTF format is not supported under the PBR mode.
+        /// </summary>
+        /// <returns>Error code = 1130 </returns>
+        public int ERR_GLTF_NOT_SUPPORT_PBR_TEXTURE_MODE => CallStatic<int>("ERR_GLTF_NOT_SUPPORT_PBR_TEXTURE_MODE");
+        /// <summary>
+        /// Invalid parameter.
+        /// </summary>
+        /// <returns>Error code = 1131 </returns>
+        public int ERR_PBR_MODE_NOT_EXIST => CallStatic<int>("ERR_PBR_MODE_NOT_EXIST");
+        /// <summary>
+        /// The free quota for 3D Modeling Kit has been used up.
+        /// </summary>
+        /// <returns>Error code = 1132 </returns>
+        public int ERR_RET_BILLING_QUOTA_EXHAUSTED => CallStatic<int>("ERR_RET_BILLING_QUOTA_EXHAUSTED");
+        /// <summary>
+        /// The account balance is insufficient to use 3D Modeling Kit.
+        /// </summary>
+        /// <returns>Error code = 1133 </returns>
+        public int ERR_RET_BILLING_OVERDUE => CallStatic<int>("ERR_RET_BILLING_OVERDUE");
+        /// <summary>
+        /// The free quota for 3D Modeling Kit has been used up.
+        /// </summary>
+        /// <returns>Error code = 1134 </returns>
+        public int ERR_RET_ORDER_NOT_EXIST => CallStatic<int>("ERR_RET_ORDER_NOT_EXIST");
+        /// <summary>
+        /// Preview is not supported for auto rigging.
+        /// </summary>
+        /// <returns>Error code = 1135 </returns>
+        public int ERR_AUTO_RIGGING_NOT_SUPPORT_PREVIEW => CallStatic<int>("ERR_AUTO_RIGGING_NOT_SUPPORT_PREVIEW");
+        /// <summary>
+        /// The number of extra scanning tasks exceeds the maximum.
+        /// </summary>
+        /// <returns>Error code = 1136 </returns>
+        public int ERR_RET_OVER_RESCAN_LIMIT => CallStatic<int>("ERR_RET_OVER_RESCAN_LIMIT");
+        /// <summary>
+        /// Extra scanning is unsupported by auto rigging.
+        /// </summary>
+        /// <returns>Error code = 1138 </returns>
+        public int ERR_RET_RIGGING_NOT_SUPPORT_RESCAN => CallStatic<int>("ERR_RET_RIGGING_NOT_SUPPORT_RESCAN");
+        /// <summary>
+        /// The mesh count level of an extra scanning task is inconsistent with that of the original task.
+        /// </summary>
+        /// <returns>Error code = 1139 </returns>
+        public int ERR_RET_PARAM_FACELEVEL_NOT_CONSISTENT_WITH_RESCAN => CallStatic<int>("ERR_RET_PARAM_FACELEVEL_NOT_CONSISTENT_WITH_RESCAN");
+
+
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/ReconstructApplication.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/ReconstructApplication.cs
@@ -16,7 +16,7 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk
         private static AndroidJavaClass sJavaClass = new AndroidJavaClass("com.huawei.hms.objreconstructsdk.ReconstructApplication");
         public static explicit operator ReconstructApplication(AndroidJavaObject javaObject) => javaObject == null ? null : new ReconstructApplication(javaObject);
 
-        public ReconstructApplication GetInstance() => sJavaClass.GetStaticAsWrapper<ReconstructApplication>("getInstance");
+        public static ReconstructApplication GetInstance() => sJavaClass.GetStaticAsWrapper<ReconstructApplication>("getInstance");
         public void SetAccessToken (string accessToken) => Call("setAccessToken", accessToken.AsJavaString());
         public void SetApiKey (string apiKey) => Call("setApiKey", apiKey.AsJavaString());
 

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/ReconstructApplication.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/ReconstructApplication.cs
@@ -1,0 +1,25 @@
+using HuaweiMobileServices.Utils;
+using UnityEngine;
+
+namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk
+{
+    /// <summary>
+    /// App information. To use the on-cloud 3D object reconstruction service, set an access token or API key for your app.
+    /// </summary>
+    public class ReconstructApplication : JavaObjectWrapper
+    {
+        public ReconstructApplication(AndroidJavaObject javaObject) : base(javaObject)
+        {
+        }
+        //Not necessary to implement this because class name is the same as the java class name
+        //private static AndroidJavaClass sJavaClass = new AndroidJavaClass("com.huawei.hms.objreconstructsdk.ReconstructApplication");
+        public static explicit operator ReconstructApplication(AndroidJavaObject javaObject) => javaObject == null ? null : new ReconstructApplication(javaObject);
+
+        public string AppName => CallAsString("getAppName");
+        public ReconstructApplication GetInstance() => CallStatic<ReconstructApplication>("getInstance");
+        public void SetAccessToken (string accessToken) => Call("setAccessToken", accessToken);
+        public void SetApiKey (string apiKey) => Call("setApiKey", apiKey);
+        public void SetAppId (string appId) => Call("setAppId", appId);
+
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/ReconstructApplication.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/ReconstructApplication.cs
@@ -5,21 +5,20 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk
 {
     /// <summary>
     /// App information. To use the on-cloud 3D object reconstruction service, set an access token or API key for your app.
+    /// Wrapper for com.huawei.hms.objreconstructsdk.ReconstructApplication
+    /// <see cref="ReconstructApplication" link="https://developer.huawei.com/consumer/en/doc/development/graphics-References/reconstructapplication-0000001110787240"/>
     /// </summary>
     public class ReconstructApplication : JavaObjectWrapper
     {
         public ReconstructApplication(AndroidJavaObject javaObject) : base(javaObject)
         {
         }
-        //Not necessary to implement this because class name is the same as the java class name
-        //private static AndroidJavaClass sJavaClass = new AndroidJavaClass("com.huawei.hms.objreconstructsdk.ReconstructApplication");
+        private static AndroidJavaClass sJavaClass = new AndroidJavaClass("com.huawei.hms.objreconstructsdk.ReconstructApplication");
         public static explicit operator ReconstructApplication(AndroidJavaObject javaObject) => javaObject == null ? null : new ReconstructApplication(javaObject);
 
-        public string AppName => CallAsString("getAppName");
-        public ReconstructApplication GetInstance() => CallStatic<ReconstructApplication>("getInstance");
-        public void SetAccessToken (string accessToken) => Call("setAccessToken", accessToken);
-        public void SetApiKey (string apiKey) => Call("setApiKey", apiKey);
-        public void SetAppId (string appId) => Call("setAppId", appId);
+        public ReconstructApplication GetInstance() => sJavaClass.GetStaticAsWrapper<ReconstructApplication>("getInstance");
+        public void SetAccessToken (string accessToken) => Call("setAccessToken", accessToken.AsJavaString());
+        public void SetApiKey (string apiKey) => Call("setApiKey", apiKey.AsJavaString());
 
     }
 }

--- a/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/ReconstructApplication.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Modeling3D/ObjReconstructSdk/ReconstructApplication.cs
@@ -16,7 +16,7 @@ namespace HuaweiMobileServices.Modeling3D.ObjReconstructSdk
         private static AndroidJavaClass sJavaClass = new AndroidJavaClass("com.huawei.hms.objreconstructsdk.ReconstructApplication");
         public static explicit operator ReconstructApplication(AndroidJavaObject javaObject) => javaObject == null ? null : new ReconstructApplication(javaObject);
 
-        public static ReconstructApplication GetInstance() => sJavaClass.GetStaticAsWrapper<ReconstructApplication>("getInstance");
+        public static ReconstructApplication GetInstance() => sJavaClass.CallStaticAsWrapper<ReconstructApplication>("getInstance");
         public void SetAccessToken (string accessToken) => Call("setAccessToken", accessToken.AsJavaString());
         public void SetApiKey (string apiKey) => Call("setApiKey", apiKey.AsJavaString());
 

--- a/hms-sdk-unity/HuaweiMobileServices/Utils/AndroidFolderPicker.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Utils/AndroidFolderPicker.cs
@@ -1,0 +1,43 @@
+using System;
+using UnityEngine;
+
+namespace HuaweiMobileServices.Utils
+{
+    public static class AndroidFolderPicker
+    {
+        private const string OPEN_DOCUMENT_TREE = "android.intent.action.OPEN_DOCUMENT_TREE";
+        private static readonly AndroidJavaClass sJavaClass = new AndroidJavaClass("org.m0skit0.android.hms.unity.GenericBridge");
+        public static Action<AndroidIntent> mOnSuccessListener;
+        public static Action<HMSException> mOnFailureListener;
+
+        public static void ShowFolderPicker(AndroidJavaObject intent) {
+
+            var callback = new GenericBridgeCallbackWrapper()
+            .AddOnFailureListener(mOnFailureListener)
+            .AddOnSuccessListener((nothing) =>
+            {
+               HMSDispatcher.InvokeAsync(() => { mOnSuccessListener.Invoke(nothing); });    
+            });
+            sJavaClass.CallStatic("receiveShow", intent, callback);
+        }
+
+        public static void OpenFolderPicker()
+        {
+            mOnSuccessListener += (data) => {
+                Debug.Log("[HMS] FolderPicker: Success: " + data.GetData()?.GetPath);
+            };
+
+            mOnFailureListener += (exception) => {
+                Debug.Log("[HMS] FolderPicker: Failure: " + exception.Message);
+            };
+            AndroidIntent openFolderIntent = new AndroidIntent(OPEN_DOCUMENT_TREE)
+            .AddFlags(1)
+            .AddFlags(2)
+            .AddFlags(4)
+            .AddFlags(64);
+
+            ShowFolderPicker(openFolderIntent.JavaObject);
+        }
+    }
+
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Utils/AndroidIntent.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Utils/AndroidIntent.cs
@@ -6,7 +6,6 @@
     public class AndroidIntent : JavaObjectWrapper
     {
         public AndroidIntent(AndroidJavaObject javaObject) : base(javaObject) { }
-
         public AndroidIntent(AndroidJavaClass activityClass) : base("android.content.Intent", AndroidContext.ActivityContext, activityClass) { }
         public AndroidIntent(string action) : base("android.content.Intent", action) { }
         public AndroidIntent() : base("android.content.Intent") { }
@@ -32,5 +31,9 @@
         public AndroidIntent PutExtra(string name, byte value) => CallAsWrapper<AndroidIntent>("putExtra", name, value);
 
         public AndroidIntent PutExtra(string name, int value) => CallAsWrapper<AndroidIntent>("putExtra", name, value);
+        public AndroidIntent AddCategory(string name) => CallAsWrapper<AndroidIntent>("addCategory", name);
+        public AndroidIntent AddFlags(int flag) => CallAsWrapper<AndroidIntent>("addFlags", flag);
+        public AndroidIntent SetType(string type) => CallAsWrapper<AndroidIntent>("setType", type);
+        public Uri GetData() => CallAsWrapper<Uri>("getData");
     }
 }

--- a/hms-sdk-unity/HuaweiMobileServices/Utils/AndroidToast.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Utils/AndroidToast.cs
@@ -1,0 +1,34 @@
+namespace HuaweiMobileServices.Utils
+{
+    using UnityEngine;
+
+    //https://developer.android.com/reference/android/widget/Toast
+    public class AndroidToast : JavaObjectWrapper
+    {
+        public AndroidToast(AndroidJavaObject javaObject) : base(javaObject) { }
+
+        public AndroidToast() : base("android.widget.Toast", AndroidContext.ActivityContext) { }
+
+        private static AndroidJavaClass sJavaClass = new AndroidJavaClass("android.widget.Toast");
+
+        public static implicit operator AndroidJavaObject(AndroidToast toast) => toast.JavaObject;
+
+        public AndroidJavaObject Toast => JavaObject;
+
+        /// <summary>
+        /// Show the view or text notification for a short period of time.  This time
+        /// could be user-definable.This is the default. <see cref="SetDuration"/>
+        /// </summary>
+        public static int LENGTH_SHORT => sJavaClass.Get<int>("LENGTH_SHORT"); //0
+        /// <summary>
+        /// Show the view or text notification for a long period of time.  This time
+        /// could be user-definable. <see cref="SetDuration"/>
+        /// </summary>
+        public static int LENGTH_LONG => sJavaClass.Get<int>("LENGTH_LONG"); //1
+
+        public static AndroidToast MakeText(string text, int duration = 1) => 
+                                sJavaClass.CallStaticAsWrapper<AndroidToast>("makeText", AndroidContext.ActivityContext, text.AsJavaString(), duration);
+        public void Show() => Call("show");
+
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Utils/JavaObjectWrapper.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Utils/JavaObjectWrapper.cs
@@ -41,6 +41,9 @@ namespace HuaweiMobileServices.Utils
         internal protected int CallAsInt(string methodName, params object[] args) =>
             Call<AndroidJavaObject>(methodName, args.AsAutoParams()).AsInt();
 
+        internal protected long? CallAsLong(string methodName, params object[] args) =>
+            Call<AndroidJavaObject>(methodName, args.AsAutoParams()).AsLong();
+
         internal protected bool CallAsBool(string methodName, params object[] args) =>
             Call<AndroidJavaObject>(methodName, args.AsAutoParams()).AsBool();
 

--- a/hms-sdk-unity/HuaweiMobileServices/Utils/JavaObjectWrapper.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Utils/JavaObjectWrapper.cs
@@ -37,6 +37,9 @@ namespace HuaweiMobileServices.Utils
 
         internal protected string CallAsString(string methodName, params object[] args) =>
             Call<AndroidJavaObject>(methodName, args.AsAutoParams())?.AsString();
+        
+        internal protected int CallAsInt(string methodName, params object[] args) =>
+            Call<AndroidJavaObject>(methodName, args.AsAutoParams()).AsInt();
 
         internal protected bool CallAsBool(string methodName, params object[] args) =>
             Call<AndroidJavaObject>(methodName, args.AsAutoParams()).AsBool();

--- a/hms-sdk-unity/HuaweiMobileServices/Utils/Uri.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Utils/Uri.cs
@@ -7,10 +7,10 @@ namespace HuaweiMobileServices.Utils
     {
 
         private const string CLASS_NAME = "android.net.Uri";
-
         public Uri(AndroidJavaObject javaObject) : base(javaObject) { }
 
-        public string ToString() => CallAsString("toString");
+        public override string ToString() => CallAsString("toString");
+        public string GetPath => CallAsString("getPath");
 
     }
 }


### PR DESCRIPTION
[HUP-577] Improvement 3D Modeling object struct sdk and add CallAsInt method for Java.Interger.

[HUP-578] Improvement 3D Modeling object struct cloud sdk.

Extra methods and arguments were removed. Asjavastring extension was used for string. Fixed getInstance metod call style.

[HUP-572] Improvement 3D modelling meterial generate sdk.

[HUP-573] Improvement 3D modeling meterial generate sdk cloud.

[HUP-578],[HUP-577] Fixed some String, Interger and context problems and add todo some code lines about Modeling3dReconstruct sdk.

[HUP-573],[HUP-572] Fixed some java String, Integer and context problems and add todo some code lines about Modeling3d Meterial Generation sdk.

[HUP-575] Improvement 3D Modeling Capture sdk.(objectreconstruct-slam)

[HUP-578,577,573,572] Forgotten static tags have been added to methods and fields.

[HUP-604] Improvement 3D Modeling Reconstruct Sdk Cloud Rebody. Also added CallAsLong method.

Fixed the type of call from java in the GetInstance method, modeling3dreconstructengine fixed InitTask return type and modeling3dreconstruct listener OnResult to onResult.

3d Modeling Reconstruct and Capture image engine some problems solved like function parameters and constructor.