### PR TITLE
Update deprecated methods in PlayersClientWrapper and IPlayersClient.

### DIFF
--- a/hms-sdk-unity/HuaweiMobileServices/Game/IPlayersClient.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Game/IPlayersClient.cs
@@ -6,6 +6,7 @@
     // Wrapper for com.huawei.hms.jos.games.PlayersClient
     public interface IPlayersClient
     {
+        [Obsolete("Use GetGamePlayer instead.")]
         ITask<Player> CurrentPlayer { get; }
 
         ITask<Player> GamePlayer { get; }
@@ -26,6 +27,7 @@
 
         ITask<string> SubmitPlayerEvent(string eventId, string eventType);
 
+        [Obsolete("This method has been deprecated. ")]
         void SetGameTrialProcess(Action onTrialTimeOut, Action<bool> onCheckRealNameResult);
     }
 

--- a/hms-sdk-unity/HuaweiMobileServices/Game/Player.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Game/Player.cs
@@ -7,8 +7,6 @@ namespace HuaweiMobileServices.Game
     // Wrapper for com.huawei.hms.jos.games.player.Player
     public class Player : JavaObjectWrapper
     {
-
-        
         public Player(AndroidJavaObject javaObject) : base(javaObject) { }
 
         public Player(string json, AuthHuaweiId authHuaweiId)
@@ -22,6 +20,7 @@ namespace HuaweiMobileServices.Game
 
         public virtual int Level => Call<int>("getLevel");
 
+        [System.Obsolete("The PlayerId field will be deprecated in the future. It is recommended that you use OpenId instead of PlayerId to uniquely identify a player in a game.")]
         public virtual string PlayerId => CallAsString("getPlayerId");
 
         public virtual bool HasHiResImage() => Call<bool>("hasHiResImage");

--- a/hms-sdk-unity/HuaweiMobileServices/Game/PlayersClientWrapper.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Game/PlayersClientWrapper.cs
@@ -1,15 +1,18 @@
 namespace HuaweiMobileServices.Game
 {
+    using System;
     using HuaweiMobileServices.Base;
     using HuaweiMobileServices.Utils;
     using UnityEngine;
 
-    internal class PlayersClientWrapper : JavaObjectWrapper, IPlayersClient
+    public class PlayersClientWrapper : JavaObjectWrapper, IPlayersClient
     {
+        //https://developer.huawei.com/consumer/en/doc/HMSCore-References/playersclient-0000001050121668
         public PlayersClientWrapper(AndroidJavaObject javaObject) : base(javaObject) { }
 
+        [Obsolete("Use GetGamePlayer instead.")]
         public ITask<Player> CurrentPlayer => CallAsWrapper<TaskJavaObjectWrapper<Player>>("getCurrentPlayer");
-
+        
         public ITask<Player> GamePlayer => CallAsWrapper<TaskJavaObjectWrapper<Player>>("getGamePlayer");
 
         public ITask<Player> GetGamePlayer(bool isRequirePlayerId) => CallAsWrapper<TaskJavaObjectWrapper<Player>>("getGamePlayer", isRequirePlayerId);
@@ -23,17 +26,17 @@ namespace HuaweiMobileServices.Game
         public ITask<PlayerExtraInfo> GetPlayerExtraInfo(string transactionId) =>
              CallAsWrapper<TaskJavaObjectWrapper<PlayerExtraInfo>>("getPlayerExtraInfo", transactionId.AsJavaString());
 
-        public ITask<Void> SavePlayerInfo(AppPlayerInfo paramAppPlayerInfo)
+        public ITask<Utils.Void> SavePlayerInfo(AppPlayerInfo paramAppPlayerInfo)
         {
             var javaTask = Call<AndroidJavaObject>("savePlayerInfo", paramAppPlayerInfo.JavaObject);
             return new TaskVoidWrapper(javaTask);
         }
 
-        public void SetGameTrialProcess(System.Action onTrialTimeOut, System.Action<bool> onCheckRealNameResult) => Call("setGameTrialProcess", new GameTrialProcessWrapper(onTrialTimeOut, onCheckRealNameResult));
+        [Obsolete("This method has been deprecated.")]
+        public void SetGameTrialProcess(Action onTrialTimeOut, Action<bool> onCheckRealNameResult) => Call("setGameTrialProcess", new GameTrialProcessWrapper(onTrialTimeOut, onCheckRealNameResult));
 
         public ITask<string> SubmitPlayerEvent(string playerId, string eventId, string eventType) =>
             CallAsWrapper<TaskStringWrapper>("submitPlayerEvent", playerId.AsJavaString(), eventId.AsJavaString(), eventType.AsJavaString());
-
 
         /// <summary>
         /// If you use OpenId to identify users, use this method to report player events.
@@ -42,6 +45,7 @@ namespace HuaweiMobileServices.Game
         /// <param name="eventType">Event Type</param>
         /// <returns></returns>
         public ITask<string> SubmitPlayerEvent(string eventId, string eventType) => CallAsWrapper<TaskStringWrapper>("submitPlayerEvent", eventId.AsJavaString(), eventType.AsJavaString());
-
     }
 }
+
+//TODO - Add the Result Codes class


### PR DESCRIPTION
-CurrentPlayer and SetGameTrialProcess deprecated in IPlayersClient and PlayerClientWrapper. -PlayerId will be deprecate in the feature.

@alihan98ersoy 