### PR TITLE
[HUP-823] Feature: Added AppInfo and PromoteInfo classes and edited related class(NativeAd).

### DIFF
--- a/hms-sdk-unity/HuaweiMobileServices/Ads/AppInfo.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Ads/AppInfo.cs
@@ -1,0 +1,41 @@
+﻿using HuaweiMobileServices.Utils;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace HuaweiMobileServices.Ads
+{
+    // https://developer.huawei.com/consumer/en/doc/HMSCore-References/appinfo-0000001600190342
+    //https://developer.huawei.com/consumer/en/doc/HMSCore-References/nativead-0000001133473814#section16461225471
+    // wrapper for com.huawei.hms.ads.AppInfo
+    public class AppInfo : JavaObjectWrapper
+    {
+        public AppInfo(AndroidJavaObject javaObject) : base(javaObject) { }
+
+        public string AppName => Call<string>("getAppName");
+
+        public string AppDescription => Call<string>("getAppDesc");
+
+        public string AppIconUrl => Call<string>("getAppIconUrl");
+
+        public string AppDetailUrl => Call<string>("getAppDetailUrl");
+
+        public string VersionName => Call<string>("getVersionName");
+
+        public string DeveloperName => Call<string>("getDeveloperName");
+
+        public string DownloadUrl => Call<string>("getDownloadUrl");
+
+        public string SafeDownloadUrl => Call<string>("getSafeDownloadUrl");
+
+        public string PrivacyPolicyLink => Call<string>("getPrivacyLink");
+
+        public string PermissionUrl => Call<string>("getPermissionUrl");
+
+        public void ShowPrivacyPolicy() => Call("showPrivacyPolicy", AndroidContext.ActivityContext);
+
+        public void ShowPermissionPage() => Call("showPermissionPage", AndroidContext.ActivityContext);
+
+    }
+}

--- a/hms-sdk-unity/HuaweiMobileServices/Ads/NativeAd/NativeAd.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Ads/NativeAd/NativeAd.cs
@@ -87,7 +87,7 @@ namespace HuaweiMobileServices.Ads.NativeAd
 
         public void SetDislikeAdListener(DislikeAdListener listener) => Call("setAdListener", listener);
 
-        public Bundle ExtraBundle 
+        public Bundle ExtraBundle
         {
             get => CallAsWrapper<Bundle>("getExtraBundle");
         }
@@ -145,7 +145,7 @@ namespace HuaweiMobileServices.Ads.NativeAd
 
         public void SetRewardVerifyConfig(RewardVerifyConfig config) => Call("setRewardVerifyConfig", config);
 
-        public Map<string, string> Ext 
+        public Map<string, string> Ext
         {
             get => CallAsWrapper<Map<string, string>>("getExt");
         }
@@ -172,6 +172,24 @@ namespace HuaweiMobileServices.Ads.NativeAd
             get => Call<string>("getHwChannelId");
         }
 
+        public bool HasAdvertiserInfo() => Call<bool>("hasAdvertiserInfo");
+
+        public IList<AdvertiserInfo> AdvertiserInfo => CallAsWrapperList<AdvertiserInfo>("getAdvertiserInfo");
+
+        public void ShowAppDetailPage() => Call("showAppDetailPage", AndroidContext.ActivityContext);
+
+        public bool IsShowAppElement() => Call<bool>("isShowAppElement");
+
+        public bool IsTransparencyOpen() => Call<bool>("isTransparencyOpen");
+
+        public string GetTransparencyTplUrl() => Call<string>("getTransparencyTplUrl");
+
+        public AppInfo AppInfo => CallAsWrapper<AppInfo>("getAppInfo");
+
+        public PromoteInfo PromoteInfo => CallAsWrapper<PromoteInfo>("getPromoteInfo");
+
+
+
         public class ChoicesInfo : JavaObjectWrapper
         {
             public ChoicesInfo(AndroidJavaObject javaObject) : base(javaObject) { }
@@ -183,17 +201,11 @@ namespace HuaweiMobileServices.Ads.NativeAd
                 get => Call<string>("getContent");
             }
 
-           public IList<Image> Icons
+            public IList<Image> Icons
             {
                 get => CallAsWrapperList<Image>("getIcons");
             }
 
-            public bool HasAdvertiserInfo() => Call<bool>("hasAdvertiserInfo");
-
-            public IList<AdvertiserInfo> AdvertiserInfo
-            {
-                get => CallAsWrapperList<AdvertiserInfo>("getAdvertiserInfo");
-            }
         }
     }
 }

--- a/hms-sdk-unity/HuaweiMobileServices/Ads/PromoteInfo.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/Ads/PromoteInfo.cs
@@ -1,0 +1,25 @@
+﻿using HuaweiMobileServices.Utils;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace HuaweiMobileServices.Ads
+{
+    //https://developer.huawei.com/consumer/en/doc/HMSCore-References/promoteinfo-0000001750234640
+    //https://developer.huawei.com/consumer/en/doc/HMSCore-References/nativead-0000001133473814#section6726104634610
+    // Wrapper for com.huawei.hms.ads.base.PromoteInfo
+    // com.huawei.openalliance.ad.beans.metadata.PromoteInfo
+    public class PromoteInfo : JavaObjectWrapper
+    {
+        public PromoteInfo(AndroidJavaObject javaObject) : base(javaObject) { }
+
+        /*Promotion subtype.
+          1-  Quick app.
+          2-  WeChat mini-program.
+        */
+        public int Type => Call<int>("getType");
+
+        public string Name => Call<string>("getName");
+    }
+}


### PR DESCRIPTION
[Version Change History
](https://developer.huawei.com/consumer/en/doc/HMSCore-Guides/publisher-service-version-change-history-0000001050066909)

**New Features**

- Added the [PromoteInfo](https://developer.huawei.com/consumer/en/doc/HMSCore-References/promoteinfo-0000001750234640) and [AppInfo](https://developer.huawei.com/consumer/en/doc/HMSCore-References/appinfo-0000001600190342) classes and edited NativeAd.
- Added new methods [isTransparencyOpen](https://developer.huawei.com/consumer/en/doc/HMSCore-References/nativead-0000001050066855#section46781614202611), [getTransparencyTplUrl](https://developer.huawei.com/consumer/en/doc/HMSCore-References/nativead-0000001050066855#section14741033103111) and [showAppDetailPage](https://developer.huawei.com/consumer/en/doc/HMSCore-References/nativead-0000001050066855#section2653135691812) in NativeAd.

**Test**

This feature was tested on Android 13 and didn't result in any errors.


**Reviewer**

@alihan98ersoy 