### PR TITLE
feat: Add MLRemoteModel class for remote ML models

### DIFF
--- a/hms-sdk-unity/HuaweiMobileServices/ML/Translate/Local/MLLocalTranslatorModel.cs
+++ b/hms-sdk-unity/HuaweiMobileServices/ML/Translate/Local/MLLocalTranslatorModel.cs
@@ -1,11 +1,12 @@
-﻿using HuaweiMobileServices.Utils;
+﻿using HuaweiMobileServices.ML.DownloadModel;
+using HuaweiMobileServices.Utils;
 using UnityEngine;
 
 namespace HuaweiMobileServices.ML.Translate.Local
 {
     // Wrapper for com.huawei.hms.mlsdk.translate.local.MLLocalTranslatorModel
     // https://developer.huawei.com/consumer/en/doc/hiai-References/mllocaltranslatormodel-0000001050444213
-    public class MLLocalTranslatorModel : JavaObjectWrapper
+    public class MLLocalTranslatorModel : MLRemoteModel
     {
         public const string CLASS_NAME = "com.huawei.hms.mlsdk.translate.local.MLLocalTranslatorModel";
 


### PR DESCRIPTION
The code changes introduce a new class, `MLRemoteModel`, which is responsible for handling remote ML models. This class is added to support the functionality of downloading and using ML models offline. The addition of this class is in line with the recent commits that have been made to create download model classes for offline use and local translation.